### PR TITLE
Clean up newer gateway server tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3605,6 +3606,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,7 @@ dependencies = [
  "futures-util",
  "hmac",
  "rand 0.8.5",
+ "rstest",
  "secrecy",
  "serde",
  "serde_json",
@@ -1499,6 +1500,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2681,6 +2688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.4+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,6 +3023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,6 +3082,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3135,6 +3187,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3815,8 +3876,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3829,6 +3890,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3837,8 +3907,29 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
  "winnow 0.7.15",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ frankclaw-cron = { path = "crates/frankclaw-cron" }
 frankclaw-media = { path = "crates/frankclaw-media" }
 frankclaw-tools = { path = "crates/frankclaw-tools" }
 frankclaw-plugin-sdk = { path = "crates/frankclaw-plugin-sdk" }
+tempfile = "3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ frankclaw-cron = { path = "crates/frankclaw-cron" }
 frankclaw-media = { path = "crates/frankclaw-media" }
 frankclaw-tools = { path = "crates/frankclaw-tools" }
 frankclaw-plugin-sdk = { path = "crates/frankclaw-plugin-sdk" }
+rstest = "0.25"
 tempfile = "3"
 
 [profile.release]

--- a/crates/frankclaw-gateway/Cargo.toml
+++ b/crates/frankclaw-gateway/Cargo.toml
@@ -35,3 +35,6 @@ rand = { workspace = true }
 async-trait = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/frankclaw-gateway/Cargo.toml
+++ b/crates/frankclaw-gateway/Cargo.toml
@@ -37,4 +37,5 @@ hmac = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/frankclaw-gateway/src/lib.rs
+++ b/crates/frankclaw-gateway/src/lib.rs
@@ -19,3 +19,6 @@ pub mod tunnel;
 pub mod webhook_limiter;
 pub mod webhooks;
 pub mod ws;
+
+#[cfg(test)]
+pub(crate) mod test_fixtures;

--- a/crates/frankclaw-gateway/src/server.rs
+++ b/crates/frankclaw-gateway/src/server.rs
@@ -1722,6 +1722,7 @@ mod tests {
     use frankclaw_core::types::Role;
     use frankclaw_sessions::SqliteSessionStore;
     use frankclaw_media::MediaStore;
+    use rstest::rstest;
     use secrecy::{ExposeSecret, SecretString};
     use tower::ServiceExt;
     use crate::test_fixtures::TestTempDir;
@@ -1841,6 +1842,173 @@ mod tests {
         async fn drain(&self) -> Vec<OutboundMessage> {
             let mut sent = self.sent.lock().await;
             std::mem::take(&mut *sent)
+        }
+    }
+
+    #[derive(Debug)]
+    struct ChannelRoundtripCase {
+        channel_id: &'static str,
+        label: &'static str,
+        account: serde_json::Value,
+        sender_id: &'static str,
+        thread_id: &'static str,
+        text: &'static str,
+        platform_message_id: &'static str,
+        expected_reply_to: Option<&'static str>,
+    }
+
+    impl ChannelRoundtripCase {
+        fn config(&self) -> FrankClawConfig {
+            let mut config = FrankClawConfig::default();
+            config.channels.insert(
+                frankclaw_core::types::ChannelId::new(self.channel_id),
+                ChannelConfig {
+                    enabled: true,
+                    accounts: vec![self.account.clone()],
+                    extra: serde_json::json!({
+                        "dm_policy": "open",
+                        "require_mention_for_groups": true
+                    }),
+                },
+            );
+            config
+        }
+
+        fn inbound(&self) -> InboundMessage {
+            InboundMessage {
+                channel: frankclaw_core::types::ChannelId::new(self.channel_id),
+                account_id: "default".into(),
+                sender_id: self.sender_id.into(),
+                sender_name: Some("User".into()),
+                thread_id: Some(self.thread_id.into()),
+                is_group: true,
+                is_mention: true,
+                text: Some(self.text.into()),
+                attachments: Vec::new(),
+                platform_message_id: Some(self.platform_message_id.into()),
+                timestamp: chrono::Utc::now(),
+            }
+        }
+    }
+
+    fn capture_channel_set(
+        channel_id: &'static str,
+        capture: Arc<CaptureChannel>,
+    ) -> Arc<ChannelSet> {
+        let mut map: HashMap<
+            frankclaw_core::types::ChannelId,
+            Arc<dyn frankclaw_core::channel::ChannelPlugin>,
+        > = HashMap::new();
+        map.insert(
+            frankclaw_core::types::ChannelId::new(channel_id),
+            capture as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
+        );
+        Arc::new(ChannelSet::from_parts(map, None, None))
+    }
+
+    fn discord_roundtrip_case() -> ChannelRoundtripCase {
+        ChannelRoundtripCase {
+            channel_id: "discord",
+            label: "Discord",
+            account: serde_json::json!({ "bot_token": "test-token" }),
+            sender_id: "user-1",
+            thread_id: "channel-42",
+            text: "<@bot> hello",
+            platform_message_id: "discord-msg-1",
+            expected_reply_to: Some("discord-msg-1"),
+        }
+    }
+
+    fn telegram_roundtrip_case() -> ChannelRoundtripCase {
+        ChannelRoundtripCase {
+            channel_id: "telegram",
+            label: "Telegram",
+            account: serde_json::json!({ "bot_token": "test-token" }),
+            sender_id: "user-1",
+            thread_id: "-100123:topic:7",
+            text: "@bot hello",
+            platform_message_id: "99",
+            expected_reply_to: Some("99"),
+        }
+    }
+
+    fn slack_roundtrip_case() -> ChannelRoundtripCase {
+        ChannelRoundtripCase {
+            channel_id: "slack",
+            label: "Slack",
+            account: serde_json::json!({
+                "app_token": "xapp-test",
+                "bot_token": "xoxb-test"
+            }),
+            sender_id: "user-1",
+            thread_id: "C123:thread:1710000000.000001",
+            text: "<@bot> hello",
+            platform_message_id: "1710000000.123456",
+            expected_reply_to: Some("1710000000.123456"),
+        }
+    }
+
+    fn signal_roundtrip_case() -> ChannelRoundtripCase {
+        ChannelRoundtripCase {
+            channel_id: "signal",
+            label: "Signal",
+            account: serde_json::json!({
+                "base_url": "http://127.0.0.1:8080",
+                "account": "+15551234567"
+            }),
+            sender_id: "+15550001111",
+            thread_id: "group:group-42",
+            text: "hello",
+            platform_message_id: "1710000000123",
+            expected_reply_to: Some("1710000000123"),
+        }
+    }
+
+    async fn assert_channel_roundtrip(case: ChannelRoundtripCase) {
+        let temp = TestTempDir::new("frankclaw-gateway-channel-roundtrip");
+        let capture = Arc::new(CaptureChannel::new(case.channel_id, case.label));
+        let channels = capture_channel_set(case.channel_id, capture.clone());
+        let (state, sessions) = build_test_state(temp.path(), case.config(), channels).await;
+
+        let inbound = case.inbound();
+        let session_key = state.runtime.session_key_for_inbound(&inbound);
+
+        process_inbound_message(state.clone(), inbound)
+            .await
+            .expect("inbound processing should succeed");
+
+        let outbound = capture.drain().await;
+        assert_eq!(outbound.len(), 1);
+        assert_eq!(outbound[0].thread_id.as_deref(), Some(case.thread_id));
+        assert_eq!(outbound[0].reply_to.as_deref(), case.expected_reply_to);
+        assert_eq!(outbound[0].text, "mock reply");
+
+        let transcript = sessions
+            .get_transcript(&session_key, 10, None)
+            .await
+            .expect("transcript should load");
+        assert_eq!(transcript.len(), 2);
+        assert_eq!(transcript[0].role, Role::User);
+        assert_eq!(transcript[1].role, Role::Assistant);
+
+        let session = sessions
+            .get(&session_key)
+            .await
+            .expect("session lookup should work")
+            .expect("session should exist");
+        assert_eq!(
+            session.metadata["delivery"]["last_reply"]["thread_id"],
+            serde_json::json!(case.thread_id)
+        );
+        assert_eq!(
+            session.metadata["delivery"]["last_reply"]["content"],
+            serde_json::json!("mock reply")
+        );
+        if let Some(reply_to) = case.expected_reply_to {
+            assert_eq!(
+                session.metadata["delivery"]["last_reply"]["reply_to"],
+                serde_json::json!(reply_to)
+            );
         }
     }
 
@@ -2443,159 +2611,16 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case::discord(discord_roundtrip_case())]
+    #[case::telegram(telegram_roundtrip_case())]
+    #[case::slack(slack_roundtrip_case())]
+    #[case::signal(signal_roundtrip_case())]
     #[tokio::test]
-    async fn discord_inbound_roundtrip_targets_thread_and_persists_metadata() {
-        let temp = TestTempDir::new("frankclaw-gateway-discord-test");
-        let mut config = FrankClawConfig::default();
-        config.channels.insert(
-            frankclaw_core::types::ChannelId::new("discord"),
-            ChannelConfig {
-                enabled: true,
-                accounts: vec![serde_json::json!({
-                    "bot_token": "test-token"
-                })],
-                extra: serde_json::json!({
-                    "dm_policy": "open",
-                    "require_mention_for_groups": true
-                }),
-            },
-        );
-
-        let capture = Arc::new(CaptureChannel::new("discord", "Discord"));
-        let mut map: HashMap<
-            frankclaw_core::types::ChannelId,
-            Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        > = HashMap::new();
-        map.insert(
-            frankclaw_core::types::ChannelId::new("discord"),
-            capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        );
-        let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
-
-        let inbound = InboundMessage {
-            channel: frankclaw_core::types::ChannelId::new("discord"),
-            account_id: "default".into(),
-            sender_id: "user-1".into(),
-            sender_name: Some("User".into()),
-            thread_id: Some("channel-42".into()),
-            is_group: true,
-            is_mention: true,
-            text: Some("<@bot> hello".into()),
-            attachments: Vec::new(),
-            platform_message_id: Some("discord-msg-1".into()),
-            timestamp: chrono::Utc::now(),
-        };
-        let session_key = state.runtime.session_key_for_inbound(&inbound);
-
-        process_inbound_message(state.clone(), inbound)
-            .await
-            .expect("inbound processing should succeed");
-
-        let outbound = capture.drain().await;
-        assert_eq!(outbound.len(), 1);
-        assert_eq!(outbound[0].thread_id.as_deref(), Some("channel-42"));
-        assert_eq!(outbound[0].text, "mock reply");
-
-        let transcript = sessions
-            .get_transcript(&session_key, 10, None)
-            .await
-            .expect("transcript should load");
-        assert_eq!(transcript.len(), 2);
-        assert_eq!(transcript[0].role, Role::User);
-        assert_eq!(transcript[1].role, Role::Assistant);
-
-        let session = sessions
-            .get(&session_key)
-            .await
-            .expect("session lookup should work")
-            .expect("session should exist");
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["thread_id"],
-            serde_json::json!("channel-42")
-        );
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["content"],
-            serde_json::json!("mock reply")
-        );
-    }
-
-    #[tokio::test]
-    async fn telegram_inbound_roundtrip_targets_topic_and_persists_metadata() {
-        let temp = TestTempDir::new("frankclaw-gateway-telegram-test");
-        let mut config = FrankClawConfig::default();
-        config.channels.insert(
-            frankclaw_core::types::ChannelId::new("telegram"),
-            ChannelConfig {
-                enabled: true,
-                accounts: vec![serde_json::json!({
-                    "bot_token": "test-token"
-                })],
-                extra: serde_json::json!({
-                    "dm_policy": "open",
-                    "require_mention_for_groups": true
-                }),
-            },
-        );
-
-        let capture = Arc::new(CaptureChannel::new("telegram", "Telegram"));
-        let mut map: HashMap<
-            frankclaw_core::types::ChannelId,
-            Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        > = HashMap::new();
-        map.insert(
-            frankclaw_core::types::ChannelId::new("telegram"),
-            capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        );
-        let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
-
-        let inbound = InboundMessage {
-            channel: frankclaw_core::types::ChannelId::new("telegram"),
-            account_id: "default".into(),
-            sender_id: "user-1".into(),
-            sender_name: Some("User".into()),
-            thread_id: Some("-100123:topic:7".into()),
-            is_group: true,
-            is_mention: true,
-            text: Some("@bot hello".into()),
-            attachments: Vec::new(),
-            platform_message_id: Some("99".into()),
-            timestamp: chrono::Utc::now(),
-        };
-        let session_key = state.runtime.session_key_for_inbound(&inbound);
-
-        process_inbound_message(state.clone(), inbound)
-            .await
-            .expect("inbound processing should succeed");
-
-        let outbound = capture.drain().await;
-        assert_eq!(outbound.len(), 1);
-        assert_eq!(outbound[0].thread_id.as_deref(), Some("-100123:topic:7"));
-        assert_eq!(outbound[0].reply_to.as_deref(), Some("99"));
-        assert_eq!(outbound[0].text, "mock reply");
-
-        let transcript = sessions
-            .get_transcript(&session_key, 10, None)
-            .await
-            .expect("transcript should load");
-        assert_eq!(transcript.len(), 2);
-        assert_eq!(transcript[0].role, Role::User);
-        assert_eq!(transcript[1].role, Role::Assistant);
-
-        let session = sessions
-            .get(&session_key)
-            .await
-            .expect("session lookup should work")
-            .expect("session should exist");
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["thread_id"],
-            serde_json::json!("-100123:topic:7")
-        );
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["reply_to"],
-            serde_json::json!("99")
-        );
+    async fn inbound_roundtrip_targets_thread_and_persists_metadata(
+        #[case] case: ChannelRoundtripCase,
+    ) {
+        assert_channel_roundtrip(case).await;
     }
 
     #[tokio::test]
@@ -2658,164 +2683,6 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn slack_inbound_roundtrip_targets_thread_and_persists_metadata() {
-        let temp = TestTempDir::new("frankclaw-gateway-slack-test");
-        let mut config = FrankClawConfig::default();
-        config.channels.insert(
-            frankclaw_core::types::ChannelId::new("slack"),
-            ChannelConfig {
-                enabled: true,
-                accounts: vec![serde_json::json!({
-                    "app_token": "xapp-test",
-                    "bot_token": "xoxb-test"
-                })],
-                extra: serde_json::json!({
-                    "dm_policy": "open",
-                    "require_mention_for_groups": true
-                }),
-            },
-        );
-
-        let capture = Arc::new(CaptureChannel::new("slack", "Slack"));
-        let mut map: HashMap<
-            frankclaw_core::types::ChannelId,
-            Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        > = HashMap::new();
-        map.insert(
-            frankclaw_core::types::ChannelId::new("slack"),
-            capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        );
-        let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
-
-        let inbound = InboundMessage {
-            channel: frankclaw_core::types::ChannelId::new("slack"),
-            account_id: "default".into(),
-            sender_id: "user-1".into(),
-            sender_name: Some("User".into()),
-            thread_id: Some("C123:thread:1710000000.000001".into()),
-            is_group: true,
-            is_mention: true,
-            text: Some("<@bot> hello".into()),
-            attachments: Vec::new(),
-            platform_message_id: Some("1710000000.123456".into()),
-            timestamp: chrono::Utc::now(),
-        };
-        let session_key = state.runtime.session_key_for_inbound(&inbound);
-
-        process_inbound_message(state.clone(), inbound)
-            .await
-            .expect("inbound processing should succeed");
-
-        let outbound = capture.drain().await;
-        assert_eq!(outbound.len(), 1);
-        assert_eq!(
-            outbound[0].thread_id.as_deref(),
-            Some("C123:thread:1710000000.000001")
-        );
-        assert_eq!(outbound[0].text, "mock reply");
-
-        let transcript = sessions
-            .get_transcript(&session_key, 10, None)
-            .await
-            .expect("transcript should load");
-        assert_eq!(transcript.len(), 2);
-        assert_eq!(transcript[0].role, Role::User);
-        assert_eq!(transcript[1].role, Role::Assistant);
-
-        let session = sessions
-            .get(&session_key)
-            .await
-            .expect("session lookup should work")
-            .expect("session should exist");
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["thread_id"],
-            serde_json::json!("C123:thread:1710000000.000001")
-        );
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["reply_to"],
-            serde_json::json!("1710000000.123456")
-        );
-    }
-
-    #[tokio::test]
-    async fn signal_inbound_roundtrip_targets_group_and_persists_metadata() {
-        let temp = TestTempDir::new("frankclaw-gateway-signal-test");
-        let mut config = FrankClawConfig::default();
-        config.channels.insert(
-            frankclaw_core::types::ChannelId::new("signal"),
-            ChannelConfig {
-                enabled: true,
-                accounts: vec![serde_json::json!({
-                    "base_url": "http://127.0.0.1:8080",
-                    "account": "+15551234567"
-                })],
-                extra: serde_json::json!({
-                    "dm_policy": "open",
-                    "require_mention_for_groups": true
-                }),
-            },
-        );
-
-        let capture = Arc::new(CaptureChannel::new("signal", "Signal"));
-        let mut map: HashMap<
-            frankclaw_core::types::ChannelId,
-            Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        > = HashMap::new();
-        map.insert(
-            frankclaw_core::types::ChannelId::new("signal"),
-            capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
-        );
-        let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
-
-        let inbound = InboundMessage {
-            channel: frankclaw_core::types::ChannelId::new("signal"),
-            account_id: "default".into(),
-            sender_id: "+15550001111".into(),
-            sender_name: Some("User".into()),
-            thread_id: Some("group:group-42".into()),
-            is_group: true,
-            is_mention: true,
-            text: Some("hello".into()),
-            attachments: Vec::new(),
-            platform_message_id: Some("1710000000123".into()),
-            timestamp: chrono::Utc::now(),
-        };
-        let session_key = state.runtime.session_key_for_inbound(&inbound);
-
-        process_inbound_message(state.clone(), inbound)
-            .await
-            .expect("inbound processing should succeed");
-
-        let outbound = capture.drain().await;
-        assert_eq!(outbound.len(), 1);
-        assert_eq!(outbound[0].thread_id.as_deref(), Some("group:group-42"));
-        assert_eq!(outbound[0].text, "mock reply");
-
-        let transcript = sessions
-            .get_transcript(&session_key, 10, None)
-            .await
-            .expect("transcript should load");
-        assert_eq!(transcript.len(), 2);
-        assert_eq!(transcript[0].role, Role::User);
-        assert_eq!(transcript[1].role, Role::Assistant);
-
-        let session = sessions
-            .get(&session_key)
-            .await
-            .expect("session lookup should work")
-            .expect("session should exist");
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["thread_id"],
-            serde_json::json!("group:group-42")
-        );
-        assert_eq!(
-            session.metadata["delivery"]["last_reply"]["reply_to"],
-            serde_json::json!("1710000000123")
-        );
-    }
 
     #[tokio::test]
     async fn webhook_http_route_verifies_signature_and_executes_runtime() {

--- a/crates/frankclaw-gateway/src/server.rs
+++ b/crates/frankclaw-gateway/src/server.rs
@@ -1702,7 +1702,7 @@ fn group_allowed(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::path::PathBuf;
+    use std::path::Path;
     use super::*;
     use std::sync::Arc;
 
@@ -1724,24 +1724,7 @@ mod tests {
     use frankclaw_media::MediaStore;
     use secrecy::{ExposeSecret, SecretString};
     use tower::ServiceExt;
-
-    struct TempTestDir {
-        path: PathBuf,
-    }
-
-    impl TempTestDir {
-        fn new(label: &str) -> Self {
-            let path = std::env::temp_dir().join(format!("{}-{}", label, uuid::Uuid::new_v4()));
-            std::fs::create_dir_all(&path).expect("temp dir should create");
-            Self { path }
-        }
-    }
-
-    impl Drop for TempTestDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.path);
-        }
-    }
+    use crate::test_fixtures::TestTempDir;
 
     #[test]
     fn merge_reloadable_config_updates_gateway_and_preserves_models() {
@@ -1949,7 +1932,7 @@ mod tests {
     }
 
     async fn build_test_state(
-        temp_dir: &PathBuf,
+        temp_dir: &Path,
         mut config: FrankClawConfig,
         channels: Arc<ChannelSet>,
     ) -> (Arc<GatewayState>, Arc<SqliteSessionStore>) {
@@ -2054,7 +2037,7 @@ mod tests {
 
     #[tokio::test]
     async fn web_inbound_roundtrip_persists_reply_and_metadata() {
-        let temp = TempTestDir::new("frankclaw-gateway-test");
+        let temp = TestTempDir::new("frankclaw-gateway-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("web"),
@@ -2069,7 +2052,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),
@@ -2129,7 +2112,7 @@ mod tests {
 
     #[tokio::test]
     async fn media_upload_and_download_roundtrip_requires_auth_and_uses_store() {
-        let temp = TempTestDir::new("frankclaw-gateway-media-test");
+        let temp = TestTempDir::new("frankclaw-gateway-media-test");
         let mut config = FrankClawConfig::default();
         config.gateway.auth = frankclaw_core::auth::AuthMode::Token {
             token: Some(SecretString::from("super-secret".to_string())),
@@ -2147,7 +2130,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, _sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, _sessions) = build_test_state(temp.path(), config, channels).await;
         let app = build_router(state.clone(), Arc::new(AuthRateLimiter::new(
             state.current_config().gateway.rate_limit.clone(),
         )));
@@ -2206,7 +2189,7 @@ mod tests {
 
     #[tokio::test]
     async fn web_inbound_accepts_attachment_only_messages() {
-        let temp = TempTestDir::new("frankclaw-gateway-web-attachment-test");
+        let temp = TestTempDir::new("frankclaw-gateway-web-attachment-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("web"),
@@ -2221,7 +2204,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),
@@ -2257,7 +2240,7 @@ mod tests {
 
     #[tokio::test]
     async fn web_inbound_http_honors_explicit_session_and_returns_it() {
-        let temp = TempTestDir::new("frankclaw-gateway-web-inbound-http-test");
+        let temp = TestTempDir::new("frankclaw-gateway-web-inbound-http-test");
         let mut config = FrankClawConfig::default();
         config.gateway.auth = frankclaw_core::auth::AuthMode::Token {
             token: Some(SecretString::from("super-secret".to_string())),
@@ -2275,7 +2258,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
         let app = build_router(state.clone(), Arc::new(AuthRateLimiter::new(
             state.current_config().gateway.rate_limit.clone(),
         )));
@@ -2361,7 +2344,7 @@ mod tests {
 
     #[tokio::test]
     async fn web_outbound_route_only_drains_messages_for_requested_recipient() {
-        let temp = TempTestDir::new("frankclaw-gateway-web-outbound-test");
+        let temp = TestTempDir::new("frankclaw-gateway-web-outbound-test");
         let mut config = FrankClawConfig::default();
         config.gateway.auth = frankclaw_core::auth::AuthMode::Token {
             token: Some(SecretString::from("super-secret".to_string())),
@@ -2379,7 +2362,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, _sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, _sessions) = build_test_state(temp.path(), config, channels).await;
         let web = state.web_channel().expect("web channel should exist");
         web.send(OutboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),
@@ -2462,7 +2445,7 @@ mod tests {
 
     #[tokio::test]
     async fn discord_inbound_roundtrip_targets_thread_and_persists_metadata() {
-        let temp = TempTestDir::new("frankclaw-gateway-discord-test");
+        let temp = TestTempDir::new("frankclaw-gateway-discord-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("discord"),
@@ -2488,7 +2471,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("discord"),
@@ -2539,7 +2522,7 @@ mod tests {
 
     #[tokio::test]
     async fn telegram_inbound_roundtrip_targets_topic_and_persists_metadata() {
-        let temp = TempTestDir::new("frankclaw-gateway-telegram-test");
+        let temp = TestTempDir::new("frankclaw-gateway-telegram-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("telegram"),
@@ -2565,7 +2548,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("telegram"),
@@ -2617,7 +2600,7 @@ mod tests {
 
     #[tokio::test]
     async fn discord_inbound_roundtrip_ignores_unlisted_group_thread() {
-        let temp = TempTestDir::new("frankclaw-gateway-discord-group-filter-test");
+        let temp = TestTempDir::new("frankclaw-gateway-discord-group-filter-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("discord"),
@@ -2644,7 +2627,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("discord"),
@@ -2677,7 +2660,7 @@ mod tests {
 
     #[tokio::test]
     async fn slack_inbound_roundtrip_targets_thread_and_persists_metadata() {
-        let temp = TempTestDir::new("frankclaw-gateway-slack-test");
+        let temp = TestTempDir::new("frankclaw-gateway-slack-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("slack"),
@@ -2704,7 +2687,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("slack"),
@@ -2758,7 +2741,7 @@ mod tests {
 
     #[tokio::test]
     async fn signal_inbound_roundtrip_targets_group_and_persists_metadata() {
-        let temp = TempTestDir::new("frankclaw-gateway-signal-test");
+        let temp = TestTempDir::new("frankclaw-gateway-signal-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("signal"),
@@ -2785,7 +2768,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("signal"),
@@ -2836,7 +2819,7 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_http_route_verifies_signature_and_executes_runtime() {
-        let temp = TempTestDir::new("frankclaw-gateway-webhook-http");
+        let temp = TestTempDir::new("frankclaw-gateway-webhook-http");
         let mut config = FrankClawConfig::default();
         config.hooks.enabled = true;
         config.hooks.token = Some("secret".into());
@@ -2845,7 +2828,7 @@ mod tests {
             "session_key": "default:web:hook-control",
         })];
         let channels = Arc::new(ChannelSet::from_parts(HashMap::new(), None, None));
-        let (state, sessions) = build_test_state(&temp.path, config.clone(), channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config.clone(), channels).await;
         let app = build_router(
             state.clone(),
             Arc::new(AuthRateLimiter::new(config.gateway.rate_limit.clone())),
@@ -2884,7 +2867,7 @@ mod tests {
 
     #[tokio::test]
     async fn whatsapp_webhook_route_verifies_and_processes_inbound_messages() {
-        let temp = TempTestDir::new("frankclaw-gateway-whatsapp-webhook");
+        let temp = TestTempDir::new("frankclaw-gateway-whatsapp-webhook");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("whatsapp"),
@@ -2917,7 +2900,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, Some(whatsapp)));
-        let (state, sessions) = build_test_state(&temp.path, config.clone(), channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config.clone(), channels).await;
         let app = build_router(
             state.clone(),
             Arc::new(AuthRateLimiter::new(config.gateway.rate_limit.clone())),
@@ -2993,7 +2976,7 @@ mod tests {
 
     #[tokio::test]
     async fn whatsapp_webhook_route_rejects_unsigned_payloads_when_app_secret_is_configured() {
-        let temp = TempTestDir::new("frankclaw-gateway-whatsapp-webhook-auth");
+        let temp = TestTempDir::new("frankclaw-gateway-whatsapp-webhook-auth");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("whatsapp"),
@@ -3027,7 +3010,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, Some(whatsapp)));
-        let (state, sessions) = build_test_state(&temp.path, config.clone(), channels).await;
+        let (state, sessions) = build_test_state(temp.path(), config.clone(), channels).await;
         let app = build_router(
             state.clone(),
             Arc::new(AuthRateLimiter::new(config.gateway.rate_limit.clone())),
@@ -3116,7 +3099,7 @@ mod tests {
     }
 
     async fn build_failing_state(
-        temp_dir: &PathBuf,
+        temp_dir: &Path,
         mut config: FrankClawConfig,
         channels: Arc<ChannelSet>,
     ) -> (Arc<GatewayState>, Arc<SqliteSessionStore>) {
@@ -3159,7 +3142,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_inbound_sends_error_reply_on_model_failure() {
-        let temp = TempTestDir::new("frankclaw-gateway-test-errreply");
+        let temp = TestTempDir::new("frankclaw-gateway-test-errreply");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("web"),
@@ -3181,7 +3164,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, _sessions) = build_failing_state(&temp.path, config, channels).await;
+        let (state, _sessions) = build_failing_state(temp.path(), config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),

--- a/crates/frankclaw-gateway/src/server.rs
+++ b/crates/frankclaw-gateway/src/server.rs
@@ -1725,6 +1725,24 @@ mod tests {
     use secrecy::{ExposeSecret, SecretString};
     use tower::ServiceExt;
 
+    struct TempTestDir {
+        path: PathBuf,
+    }
+
+    impl TempTestDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!("{}-{}", label, uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&path).expect("temp dir should create");
+            Self { path }
+        }
+    }
+
+    impl Drop for TempTestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
     #[test]
     fn merge_reloadable_config_updates_gateway_and_preserves_models() {
         let mut current = FrankClawConfig::default();
@@ -2036,10 +2054,7 @@ mod tests {
 
     #[tokio::test]
     async fn web_inbound_roundtrip_persists_reply_and_metadata() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("web"),
@@ -2054,7 +2069,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),
@@ -2110,18 +2125,11 @@ mod tests {
             session.metadata["delivery"]["last_reply"]["content"],
             serde_json::json!("mock reply")
         );
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn media_upload_and_download_roundtrip_requires_auth_and_uses_store() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-media-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-media-test");
         let mut config = FrankClawConfig::default();
         config.gateway.auth = frankclaw_core::auth::AuthMode::Token {
             token: Some(SecretString::from("super-secret".to_string())),
@@ -2139,7 +2147,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, _sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, _sessions) = build_test_state(&temp.path, config, channels).await;
         let app = build_router(state.clone(), Arc::new(AuthRateLimiter::new(
             state.current_config().gateway.rate_limit.clone(),
         )));
@@ -2194,16 +2202,11 @@ mod tests {
             .await
             .expect("download body should read");
         assert_eq!(download_body, Bytes::from_static(b"hello media"));
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn web_inbound_accepts_attachment_only_messages() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-web-attachment-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-web-attachment-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("web"),
@@ -2218,7 +2221,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),
@@ -2250,16 +2253,11 @@ mod tests {
             .await
             .expect("transcript should load");
         assert_eq!(transcript[0].content, "<media:image>");
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn web_inbound_http_honors_explicit_session_and_returns_it() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-web-inbound-http-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-web-inbound-http-test");
         let mut config = FrankClawConfig::default();
         config.gateway.auth = frankclaw_core::auth::AuthMode::Token {
             token: Some(SecretString::from("super-secret".to_string())),
@@ -2277,7 +2275,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
         let app = build_router(state.clone(), Arc::new(AuthRateLimiter::new(
             state.current_config().gateway.rate_limit.clone(),
         )));
@@ -2359,16 +2357,11 @@ mod tests {
         let outbound_json: serde_json::Value =
             serde_json::from_slice(&outbound_body).expect("outbound response should be json");
         assert_eq!(outbound_json["messages"][0]["text"], serde_json::json!("mock reply"));
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn web_outbound_route_only_drains_messages_for_requested_recipient() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-web-outbound-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-web-outbound-test");
         let mut config = FrankClawConfig::default();
         config.gateway.auth = frankclaw_core::auth::AuthMode::Token {
             token: Some(SecretString::from("super-secret".to_string())),
@@ -2386,7 +2379,7 @@ mod tests {
         let channels = Arc::new(
             frankclaw_channels::load_from_config(&config).expect("channels should load"),
         );
-        let (state, _sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, _sessions) = build_test_state(&temp.path, config, channels).await;
         let web = state.web_channel().expect("web channel should exist");
         web.send(OutboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),
@@ -2465,16 +2458,11 @@ mod tests {
             other_json["messages"][0]["attachments"][0]["url"],
             serde_json::json!("/api/media/test-photo")
         );
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn discord_inbound_roundtrip_targets_thread_and_persists_metadata() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-discord-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-discord-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("discord"),
@@ -2500,7 +2488,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("discord"),
@@ -2547,18 +2535,11 @@ mod tests {
             session.metadata["delivery"]["last_reply"]["content"],
             serde_json::json!("mock reply")
         );
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn telegram_inbound_roundtrip_targets_topic_and_persists_metadata() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-telegram-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-telegram-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("telegram"),
@@ -2584,7 +2565,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("telegram"),
@@ -2632,18 +2613,11 @@ mod tests {
             session.metadata["delivery"]["last_reply"]["reply_to"],
             serde_json::json!("99")
         );
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn discord_inbound_roundtrip_ignores_unlisted_group_thread() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-discord-group-filter-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-discord-group-filter-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("discord"),
@@ -2670,7 +2644,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("discord"),
@@ -2699,18 +2673,11 @@ mod tests {
                 .expect("session lookup should work")
                 .is_none()
         );
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn slack_inbound_roundtrip_targets_thread_and_persists_metadata() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-slack-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-slack-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("slack"),
@@ -2737,7 +2704,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("slack"),
@@ -2787,18 +2754,11 @@ mod tests {
             session.metadata["delivery"]["last_reply"]["reply_to"],
             serde_json::json!("1710000000.123456")
         );
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn signal_inbound_roundtrip_targets_group_and_persists_metadata() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-signal-test-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-signal-test");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("signal"),
@@ -2825,7 +2785,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, sessions) = build_test_state(&temp_dir, config, channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("signal"),
@@ -2872,18 +2832,11 @@ mod tests {
             session.metadata["delivery"]["last_reply"]["reply_to"],
             serde_json::json!("1710000000123")
         );
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn webhook_http_route_verifies_signature_and_executes_runtime() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-webhook-http-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-webhook-http");
         let mut config = FrankClawConfig::default();
         config.hooks.enabled = true;
         config.hooks.token = Some("secret".into());
@@ -2892,7 +2845,7 @@ mod tests {
             "session_key": "default:web:hook-control",
         })];
         let channels = Arc::new(ChannelSet::from_parts(HashMap::new(), None, None));
-        let (state, sessions) = build_test_state(&temp_dir, config.clone(), channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config.clone(), channels).await;
         let app = build_router(
             state.clone(),
             Arc::new(AuthRateLimiter::new(config.gateway.rate_limit.clone())),
@@ -2927,18 +2880,11 @@ mod tests {
         assert_eq!(transcript.len(), 2);
         assert_eq!(transcript[0].content, "hello from http hook");
         assert_eq!(transcript[1].content, "mock reply");
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn whatsapp_webhook_route_verifies_and_processes_inbound_messages() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-whatsapp-webhook-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-whatsapp-webhook");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("whatsapp"),
@@ -2971,7 +2917,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, Some(whatsapp)));
-        let (state, sessions) = build_test_state(&temp_dir, config.clone(), channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config.clone(), channels).await;
         let app = build_router(
             state.clone(),
             Arc::new(AuthRateLimiter::new(config.gateway.rate_limit.clone())),
@@ -3043,18 +2989,11 @@ mod tests {
         assert_eq!(transcript.len(), 2);
         assert_eq!(transcript[0].content, "hello from whatsapp");
         assert_eq!(transcript[1].content, "mock reply");
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     #[tokio::test]
     async fn whatsapp_webhook_route_rejects_unsigned_payloads_when_app_secret_is_configured() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-whatsapp-webhook-auth-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-whatsapp-webhook-auth");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("whatsapp"),
@@ -3088,7 +3027,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, Some(whatsapp)));
-        let (state, sessions) = build_test_state(&temp_dir, config.clone(), channels).await;
+        let (state, sessions) = build_test_state(&temp.path, config.clone(), channels).await;
         let app = build_router(
             state.clone(),
             Arc::new(AuthRateLimiter::new(config.gateway.rate_limit.clone())),
@@ -3137,10 +3076,6 @@ mod tests {
             .await
             .expect("transcript should load");
         assert!(transcript.is_empty());
-
-        let _ = std::fs::remove_file(temp_dir.join("sessions.db"));
-        let _ = std::fs::remove_file(temp_dir.join("pairings.json"));
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 
     struct FailingProvider;
@@ -3224,10 +3159,7 @@ mod tests {
 
     #[tokio::test]
     async fn process_inbound_sends_error_reply_on_model_failure() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "frankclaw-gateway-test-errreply-{}",
-            uuid::Uuid::new_v4()
-        ));
+        let temp = TempTestDir::new("frankclaw-gateway-test-errreply");
         let mut config = FrankClawConfig::default();
         config.channels.insert(
             frankclaw_core::types::ChannelId::new("web"),
@@ -3249,7 +3181,7 @@ mod tests {
             capture.clone() as Arc<dyn frankclaw_core::channel::ChannelPlugin>,
         );
         let channels = Arc::new(ChannelSet::from_parts(map, None, None));
-        let (state, _sessions) = build_failing_state(&temp_dir, config, channels).await;
+        let (state, _sessions) = build_failing_state(&temp.path, config, channels).await;
 
         let inbound = InboundMessage {
             channel: frankclaw_core::types::ChannelId::new("web"),
@@ -3278,7 +3210,5 @@ mod tests {
             sent[0].text
         );
         assert_eq!(sent[0].to, "user-1");
-
-        let _ = std::fs::remove_dir_all(temp_dir);
     }
 }

--- a/crates/frankclaw-gateway/src/test_fixtures.rs
+++ b/crates/frankclaw-gateway/src/test_fixtures.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+use tempfile::{Builder, TempDir};
+
+pub(crate) struct TestTempDir {
+    dir: TempDir,
+}
+
+impl TestTempDir {
+    pub(crate) fn new(prefix: &str) -> Self {
+        let dir = Builder::new()
+            .prefix(prefix)
+            .tempdir()
+            .expect("temp dir should create");
+        Self { dir }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        self.dir.path()
+    }
+}


### PR DESCRIPTION
This PR continues the test cleanup from #4 in the gateway server tests.

It uses the same shared gateway test fixture utility and extends the `rstest` reuse instead of introducing another one-off test pattern.

## What changed

- reuses the gateway `test_fixtures` module backed by `tempfile::TempDir`
- collapses four channel-specific inbound roundtrip tests into a single `rstest` case matrix
- keeps channel-specific inputs explicit while sharing setup and common assertions
- removes repeated temp-dir setup and teardown from those newer gateway server tests

## Why this shape

The goal is to keep the test cleanup bottom-up and reusable.

PR #4 introduces the fixture utility and applies it in gateway method tests. This PR applies the same utility one layer higher in the gateway server tests and adds a shared `rstest` matrix where the test flow is otherwise identical.

## Verification

- `cargo test -p frankclaw-gateway`
