### PR TITLE
Fix quick start clone path and directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ For channel setup, see [CHANNEL_SETUP.md](docs/CHANNEL_SETUP.md), `examples/chan
 ### 1. Build
 
 ```bash
-git clone https://github.com/frankclaw/frankclaw.git
-cd frankclaw
+git clone https://github.com/akitaonrails/FrankClaw.git
+cd FrankClaw
 cargo build --release
 ```
 


### PR DESCRIPTION
Closes #6.

## Summary

- updates the Quick Start clone URL to the current repository
- fixes the `cd` command to match the repository directory name

## Why

The current README still points to the old repository path and lowercased directory name, so following the setup instructions verbatim lands in the wrong place.

## Verification

- confirmed the Quick Start snippet in `README.md`
- searched the markdown docs for the stale clone URL and `cd frankclaw` references
